### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -339,6 +339,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @app.post("/imports", response_model=ImportResponse)
     async def import_documents(request: ImportRequest) -> ImportResponse:
+        if settings.api_import_root is None:
+            raise HTTPException(status_code=400, detail="API import root is not configured")
         container = await build_container(settings)
         try:
             conversion_format = ConversionFormat(request.format)
@@ -456,7 +458,7 @@ def _validate_api_security(settings: Settings) -> None:
 def _resolve_api_path(path: Path, *, settings: Settings) -> Path:
     resolved = path.expanduser().resolve()
     if settings.api_import_root is None:
-        return resolved
+        raise HTTPException(status_code=400, detail="API import root is not configured")
     root = settings.api_import_root.expanduser().resolve()
     try:
         resolved.relative_to(root)


### PR DESCRIPTION
Potential fix for [https://github.com/nampara-ai/librarian/security/code-scanning/1](https://github.com/nampara-ai/librarian/security/code-scanning/1)

General fix: always constrain user-supplied paths to a trusted base directory before using them, and reject requests if that base directory is not configured for features that access filesystem paths from API input.

Best fix here without changing core behavior beyond security hardening:
1. In `import_documents` (around line 341), reject the request if `settings.api_import_root` is `None` with HTTP 400 and a clear message.
2. In `_resolve_api_path` (lines 456–466), remove the permissive branch that returns arbitrary resolved paths when `api_import_root` is unset; instead raise HTTP 400 if unset. Keep the existing `relative_to(root)` containment check.

This keeps existing intended secure behavior (paths under configured root) and closes the unsafe fallback.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
