### PR TITLE
Build the Intel DMG on Apple Silicon under Rosetta (drop scarce macos-13)

### DIFF
--- a/.github/workflows/macapp.yml
+++ b/.github/workflows/macapp.yml
@@ -19,21 +19,22 @@ permissions:
 
 jobs:
   dmg:
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-14
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Build each DMG on a runner whose native architecture matches the
-          # target, so Homebrew's OCR binaries (tesseract/poppler) are the
-          # right arch without Rosetta gymnastics.
+          # Both DMGs build on plentiful Apple Silicon runners. The arm64
+          # binaries come from the native Homebrew; the x86_64 binaries come
+          # from an x86_64 Homebrew installed under Rosetta, so releases never
+          # wait on (increasingly scarce) native Intel runners.
           - arch: arm64
             artifact: Librarian-AppleSilicon
-            runner: macos-14
+            brew_prefix: /opt/homebrew
           - arch: x86_64
             artifact: Librarian-Intel
-            runner: macos-13
+            brew_prefix: /usr/local
     steps:
       - uses: actions/checkout@v6
         with:
@@ -48,6 +49,10 @@ jobs:
           python -m pip install --upgrade build
           python -m build --wheel
 
+      - name: Ensure Rosetta 2 (x86_64 build on Apple Silicon)
+        if: matrix.arch == 'x86_64'
+        run: sudo softwareupdate --install-rosetta --agree-to-license
+
       - name: Build app bundle
         working-directory: apps/macos
         run: make app ARCH_FLAGS="--arch ${{ matrix.arch }}"
@@ -60,12 +65,29 @@ jobs:
             --wheel "$(ls ../../dist/nampara_librarian-*.whl)" \
             --arch ${{ matrix.arch }}
 
-      - name: Install OCR tools (native arch)
+      - name: Install OCR tools (arm64 native Homebrew)
+        if: matrix.arch == 'arm64'
         run: brew install tesseract poppler dylibbundler
+
+      - name: Install OCR tools (x86_64 Homebrew under Rosetta)
+        if: matrix.arch == 'x86_64'
+        run: |
+          # Bootstrap an x86_64 Homebrew at /usr/local (the installer picks the
+          # prefix from the running architecture, so run it under Rosetta), then
+          # install the Intel OCR binaries there.
+          if [ ! -x /usr/local/bin/brew ]; then
+            NONINTERACTIVE=1 arch -x86_64 /bin/bash -c \
+              "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" </dev/null
+          fi
+          arch -x86_64 /usr/local/bin/brew install tesseract poppler dylibbundler
 
       - name: Bundle OCR tools
         working-directory: apps/macos
-        run: scripts/bundle_ocr.sh --app dist/Librarian.app --arch ${{ matrix.arch }}
+        run: |
+          scripts/bundle_ocr.sh \
+            --app dist/Librarian.app \
+            --arch ${{ matrix.arch }} \
+            --brew-prefix ${{ matrix.brew_prefix }}
 
       - name: Verify bundled OCR works end to end
         working-directory: apps/macos

--- a/apps/macos/scripts/bundle_backend.sh
+++ b/apps/macos/scripts/bundle_backend.sh
@@ -51,12 +51,21 @@ PYBIN="${BACKEND_DIR}/python/bin/python3"
 [[ -x "$PYBIN" ]] || { echo "Extracted Python interpreter not found at $PYBIN" >&2; exit 1; }
 
 # An x86_64 interpreter runs under Rosetta 2 on Apple Silicon, so pip can
-# install x86_64 wheels there too.
+# install x86_64 wheels there too. When cross-bundling x86_64 on an Apple
+# Silicon host, force prebuilt wheels: otherwise pip may source-build a
+# dependency (e.g. cryptography), and the native arm64 toolchain cross-compiles
+# it to x86_64 and fails (openssl-sys cannot find an x86_64 OpenSSL).
+PIP_BINARY=()
+if [[ "$PBS_ARCH" == "x86_64" && "$(uname -m)" == "arm64" ]]; then
+  PIP_BINARY+=(--only-binary=:all:)
+fi
 echo "Installing Librarian backend"
 if [[ -f "$WHEEL" ]]; then
-  "$PYBIN" -m pip install --quiet --no-warn-script-location "${WHEEL}[all]"
+  "$PYBIN" -m pip install --quiet --no-warn-script-location \
+    ${PIP_BINARY[@]+"${PIP_BINARY[@]}"} "${WHEEL}[all]"
 else
-  "$PYBIN" -m pip install --quiet --no-warn-script-location "$WHEEL"
+  "$PYBIN" -m pip install --quiet --no-warn-script-location \
+    ${PIP_BINARY[@]+"${PIP_BINARY[@]}"} "$WHEEL"
 fi
 
 "$PYBIN" -m librarian version >/dev/null

--- a/apps/macos/scripts/bundle_ocr.sh
+++ b/apps/macos/scripts/bundle_ocr.sh
@@ -44,7 +44,8 @@ if [[ "$WANT" == "x86_64" && "$HOST_ARCH" == "arm64" ]]; then
   RUN=(arch -x86_64)
 fi
 
-[[ -n "$BREW_PREFIX" ]] || BREW_PREFIX="$("${RUN[@]}" brew --prefix)"
+# ${RUN[@]+...} keeps an empty RUN array safe under `set -u` (macOS bash).
+[[ -n "$BREW_PREFIX" ]] || BREW_PREFIX="$(${RUN[@]+"${RUN[@]}"} brew --prefix)"
 DYLIBBUNDLER="$BREW_PREFIX/bin/dylibbundler"
 [[ -x "$DYLIBBUNDLER" ]] || {
   echo "dylibbundler not found at $DYLIBBUNDLER (brew install dylibbundler)" >&2
@@ -105,7 +106,7 @@ for opt_lib in "$BREW_PREFIX"/opt/*/lib; do
 done
 # -of overwrite, -b fix the binaries, -cd create the dest dir,
 # -p set the rewritten load-path prefix relative to each executable.
-"${RUN[@]}" "$DYLIBBUNDLER" -of -b -cd \
+${RUN[@]+"${RUN[@]}"} "$DYLIBBUNDLER" -of -b -cd \
   "${DYLIB_ARGS[@]}" \
   "${SEARCH_ARGS[@]}" \
   -d "$LIB_DIR" \

--- a/apps/macos/scripts/bundle_ocr.sh
+++ b/apps/macos/scripts/bundle_ocr.sh
@@ -6,31 +6,30 @@ set -euo pipefail
 # are OCR'd with zero external dependencies — no Homebrew, no PATH setup.
 #
 # Usage:
-#   scripts/bundle_ocr.sh --app dist/Librarian.app [--arch arm64|x86_64]
+#   scripts/bundle_ocr.sh --app dist/Librarian.app --arch arm64|x86_64 \
+#     [--brew-prefix /opt/homebrew]
 #
-# Must run on a runner whose native architecture matches --arch: Homebrew
-# installs binaries for the host arch, so the arm64 DMG is built on Apple
-# Silicon and the x86_64 DMG on an Intel runner. Dependent dylibs are copied
-# into the bundle and their load paths rewritten to @executable_path/../lib
-# with dylibbundler, so nothing points back at /opt/homebrew or /usr/local.
+# Both DMGs build on Apple Silicon runners (Intel runners are scarce). The
+# arm64 binaries come from the native Homebrew at /opt/homebrew; the x86_64
+# binaries come from an x86_64 Homebrew installed under Rosetta at /usr/local,
+# so --brew-prefix selects which one. Dependent dylibs are copied into the
+# bundle and their load paths rewritten to @executable_path/../lib with
+# dylibbundler, so nothing points back at Homebrew.
 
 APP=""
 ARCH="$(uname -m)"
+BREW_PREFIX=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --app) APP="$2"; shift 2 ;;
     --arch) ARCH="$2"; shift 2 ;;
+    --brew-prefix) BREW_PREFIX="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
 [[ -d "$APP" ]] || { echo "--app must point at an existing .app bundle" >&2; exit 1; }
-command -v brew >/dev/null || { echo "Homebrew is required to source OCR tools" >&2; exit 1; }
-command -v dylibbundler >/dev/null || {
-  echo "dylibbundler is required (brew install dylibbundler)" >&2
-  exit 1
-}
 
 HOST_ARCH="$(uname -m)"
 case "$ARCH" in
@@ -38,13 +37,20 @@ case "$ARCH" in
   x86_64|amd64) WANT="x86_64" ;;
   *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
 esac
-if [[ "$HOST_ARCH" != "$WANT" ]]; then
-  echo "Refusing to bundle $WANT OCR tools on a $HOST_ARCH host: Homebrew binaries" >&2
-  echo "are host-native. Build the $WANT DMG on a $WANT runner." >&2
-  exit 1
+
+# x86_64 binaries on an Apple Silicon host run (and are tooled) under Rosetta.
+RUN=()
+if [[ "$WANT" == "x86_64" && "$HOST_ARCH" == "arm64" ]]; then
+  RUN=(arch -x86_64)
 fi
 
-BREW_PREFIX="$(brew --prefix)"
+[[ -n "$BREW_PREFIX" ]] || BREW_PREFIX="$("${RUN[@]}" brew --prefix)"
+DYLIBBUNDLER="$BREW_PREFIX/bin/dylibbundler"
+[[ -x "$DYLIBBUNDLER" ]] || {
+  echo "dylibbundler not found at $DYLIBBUNDLER (brew install dylibbundler)" >&2
+  exit 1
+}
+
 OCR_DIR="$APP/Contents/Resources/ocr"
 BIN_DIR="$OCR_DIR/bin"
 LIB_DIR="$OCR_DIR/lib"
@@ -60,6 +66,15 @@ for exe in "${EXES[@]}"; do
   src="$BREW_PREFIX/bin/$exe"
   [[ -x "$src" ]] || { echo "Expected OCR tool not found: $src" >&2; exit 1; }
   cp "$src" "$BIN_DIR/$exe"
+  # Each binary must be the architecture we are packaging for.
+  archs="$(lipo -archs "$BIN_DIR/$exe" 2>/dev/null || echo "")"
+  case " $archs " in
+    *" $WANT "*) ;;
+    *)
+      echo "Bundled $exe is '$archs', expected $WANT (wrong --brew-prefix?)" >&2
+      exit 1
+      ;;
+  esac
 done
 
 # English language data (plus orientation/script data for rotation handling).
@@ -90,7 +105,7 @@ for opt_lib in "$BREW_PREFIX"/opt/*/lib; do
 done
 # -of overwrite, -b fix the binaries, -cd create the dest dir,
 # -p set the rewritten load-path prefix relative to each executable.
-dylibbundler -of -b -cd \
+"${RUN[@]}" "$DYLIBBUNDLER" -of -b -cd \
   "${DYLIB_ARGS[@]}" \
   "${SEARCH_ARGS[@]}" \
   -d "$LIB_DIR" \


### PR DESCRIPTION
## Summary

Build the Intel (x86_64) DMG on plentiful Apple Silicon runners under Rosetta instead of scarce native `macos-13` runners.

### Why
During the v1.3.0 work, I moved the x86_64 DMG to native `macos-13` Intel runners to source x86_64 Homebrew OCR binaries. In practice those runners are scarce and being deprecated — the Intel job sat **queued 30–55+ minutes** waiting for one. That's not just slow: the release workflow can't publish without the Intel DMG, so the same queue would stall — and a failure there would **burn** — the immutable `v1.3.0` tag.

### What
- Both DMGs now build on `macos-14` (Apple Silicon, plentiful). This restores the pre-OCR arrangement where both arches built on Apple Silicon.
- The x86_64 leg installs an **x86_64 Homebrew at `/usr/local` under Rosetta** and gets the Intel `tesseract`/`poppler`/`dylibbundler` there.
- `bundle_ocr.sh` gains `--brew-prefix` to select which Homebrew to copy from, runs `dylibbundler` under `arch -x86_64` for the Intel binaries, and **verifies each bundled binary's architecture with `lipo`** (so a wrong-prefix mistake fails loudly instead of shipping arm64 binaries in the Intel DMG).
- Re-adds the Rosetta 2 install step for the x86_64 leg.

### Validation
The PR's own Mac App build exercises both legs on `macos-14` — no Intel-runner queue — and the existing end-to-end OCR check (real `pdf2image → pdftoppm → tesseract` on a generated PDF) runs for the x86_64 binaries under Rosetta. Locally: `bash -n` clean, workflow YAML valid.

This is a CI/build-only change; no engine or app code, version stays `1.3.0` (untagged).

🤖 Note: macOS-specific bundling can only be exercised on CI; this PR's Mac App build is the validation gate.

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_