### PR TITLE
Add --json to core CLI commands for agent-driven bulk processing (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.4.0 - 2026-06-13
+
+Makes the CLI fully scriptable, so an agent can drive bulk document processing end to end
+without scraping human-readable tables.
+
+- `--json` now covers the core query and control commands: `ingest` and `process` return the
+  new `document_id`/`run_id` (plus run status and chunk counts), `status` returns
+  `status`/`stage`/`total_chunks`/`completed_chunks`/`failed_chunks` and the event list for
+  polling, and `list`, `show`, and `search` (with or without `--details`) return structured
+  records — `show` and detailed `search` include the Dewey code, title, tags, and summary.
+  Output is clean, unstyled JSON suitable for piping into `jq` or a parser.
+- Combined with the existing `import --recursive --process --report report.json` (full JSON
+  report), `import --manifest <path> --resume` (idempotent bulk imports across restarts),
+  non-zero exit on any failed item, and SHA-based ingest de-duplication, the CLI is now a
+  complete machine-driveable surface. The README documents the automation flow.
+
 ## 1.3.0 - 2026-06-13
 
 Scanned and image-based PDFs now work in the Mac app, out of the box.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Everything below covers the engine itself — the CLI and API the app is built o
 
 ## Install
 
+Requires **Python 3.12+**. (The Mac app needs none of this — it bundles the engine, the Python
+runtime, and the OCR tools. This section is for the CLI and API.)
+
 From PyPI:
 
 ```bash
@@ -41,6 +44,35 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev,all]"
 ```
+
+### Optional dependency extras
+
+The base install is intentionally lean; opt into capabilities with extras (or `[all]` for
+everything):
+
+| Extra | Enables |
+| --- | --- |
+| `pdf` | PDF text extraction (`pdfplumber`) |
+| `ocr` | Scanned/image-PDF OCR (`pdf2image`, `pillow`, `pytesseract`) |
+| `universal` | Broad document conversion via `markitdown` (PPTX, XLSX, Outlook, …) |
+| `otel` | OpenTelemetry tracing/metrics export |
+| `all` | All of the above |
+
+### OCR system dependencies (CLI/API only)
+
+OCR for scanned or image-based PDFs needs two **system** binaries that cannot be installed via
+pip — they must be on your `PATH`:
+
+```bash
+# macOS
+brew install tesseract poppler
+
+# Debian/Ubuntu
+sudo apt-get install -y tesseract-ocr poppler-utils
+```
+
+Without them, text-layer PDFs still work, but scanned pages cannot be read. (The Mac app bundles
+both, so app users never need this.) Run `librarian doctor` to verify what's available.
 
 ## Quick Start
 
@@ -126,3 +158,13 @@ Start with [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). API details are in [doc
 ## Privacy
 
 Librarian stores data locally by default. Text is sent to a configured model provider only when processing or OCR correction requires LLM work. API keys belong in environment variables or `.env`, never in Git. CI runs secret scanning, dependency audit, type checking, tests, package build, wheel smoke install, and Docker build checks for every pull request.
+
+## Contributing And Security
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and the
+quality gate, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations. To report a
+vulnerability, follow [SECURITY.md](SECURITY.md). Release history is in [CHANGELOG.md](CHANGELOG.md).
+
+## License
+
+Licensed under the Apache License 2.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Librarian is a local-first document ingestion, cleaning, classification, and search system. It converts transcripts, Markdown, text files, DOCX, PDFs, and OCR images into clean Markdown or plain text; processes them with an OpenAI-compatible model while preserving source fidelity; classifies the result with Dewey-style labels; and exposes the same engine through a Mac app, a CLI, and a FastAPI service.
 
-Version `1.3.0` is the stable production release. The default deployment is local or single-node: source documents and generated outputs stay in SQLite-backed local storage unless you configure an external model provider for cleaning, classification, or OCR correction.
+Version `1.4.0` is the stable production release. The default deployment is local or single-node: source documents and generated outputs stay in SQLite-backed local storage unless you configure an external model provider for cleaning, classification, or OCR correction.
 
 ## Mac App
 
@@ -31,7 +31,7 @@ From a downloaded release wheel:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install "nampara_librarian-1.3.0-py3-none-any.whl[all]"
+pip install "nampara_librarian-1.4.0-py3-none-any.whl[all]"
 ```
 
 From a source checkout:
@@ -89,6 +89,10 @@ librarian api
 ```
 
 `librarian import` converts sources into the workspace by default: converted Markdown/text lands under `<data_dir>/converted` instead of next to your original files. Use `--output-mode` to opt into `new-directory`, `original`, or `subdirectory` placement.
+
+### Automation and scripting
+
+The query and control commands emit machine-readable JSON with `--json`, so an agent can drive the whole pipeline without scraping tables: `ingest --json` and `process --json` return the new `document_id`/`run_id`; `status --json` reports `status`, `stage`, `total_chunks`, and `completed_chunks` for polling; and `list`, `show`, and `search [--details] --json` return structured records. For bulk runs, `librarian import --recursive --process --report report.json` writes a full JSON report, `--manifest <path> --resume` makes large imports idempotent across restarts, and the command exits non-zero if any item failed. `doctor --json`, `admin db-stats --json`, `admin api-audit --json`, and `admin page-manifest --json` round out the machine-readable surface.
 
 Operator commands live under `librarian admin`, including database maintenance, backups, run controls, queue inspection, API audit logs, and PDF page-manifest inspection. Release and quality harnesses live under `librarian maintainer`; they ship with source checkouts only and are excluded from release wheels.
 

--- a/apps/macos/Support/Info.plist
+++ b/apps/macos/Support/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleIconFile</key>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ import root:
 docker run --rm -p 8080:8080 \
   -e LIBRARIAN_API_KEY=change-me \
   -e LIBRARIAN_API_IMPORT_ROOT=/data/imports \
-  ghcr.io/nampara-ai/librarian:v1.3.0
+  ghcr.io/nampara-ai/librarian:v1.4.0
 ```
 
 ## Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nampara-librarian"
-version = "1.3.0"
+version = "1.4.0"
 description = "Local-first corpus cleaner and library organizer with CLI and API surfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -919,6 +919,10 @@ def inspect_queue(
 @app.command()
 def ingest(
     path: Annotated[Path, typer.Argument(exists=True, readable=True, dir_okay=False)],
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print the result as JSON."),
+    ] = False,
 ) -> None:
     """Ingest a source file and persist extracted text."""
     resolved_path = path.resolve()
@@ -926,6 +930,20 @@ def ingest(
     async def run() -> None:
         container = await build_ingest_container()
         result = await container.ingest_document.execute(resolved_path)
+        if json_output:
+            console.out(
+                json.dumps(
+                    {
+                        "document_id": str(result.document.id),
+                        "filename": result.document.source.filename,
+                        "extracted_chars": len(result.raw_text),
+                        "duplicate": result.duplicate,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return
         console.print(f"Ingested {result.document.id}")
         console.print(f"Source: {result.document.source.filename}")
         console.print(f"Extracted: {len(result.raw_text):,} chars")
@@ -936,12 +954,33 @@ def ingest(
 @app.command()
 def process(
     document_id: Annotated[str, typer.Argument(help="Document ID to process.")],
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print the run result as JSON."),
+    ] = False,
 ) -> None:
     """Process an ingested document."""
 
     async def run() -> None:
         container = await build_container()
         result = await container.process_document.execute(DocumentId(document_id))
+        if json_output:
+            console.out(
+                json.dumps(
+                    {
+                        "run_id": str(result.id),
+                        "document_id": str(result.document_id),
+                        "status": result.status.value,
+                        "stage": result.stage.value,
+                        "total_chunks": result.total_chunks,
+                        "completed_chunks": result.completed_chunks,
+                        "failed_chunks": result.failed_chunks,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return
         console.print(f"Run {result.id}: {result.status.value}")
 
     asyncio.run(run())
@@ -980,12 +1019,37 @@ def worker(
 def list_documents(
     limit: Annotated[int, typer.Option(help="Maximum documents.", min=1, max=500)] = 100,
     offset: Annotated[int, typer.Option(help="Documents to skip.", min=0)] = 0,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print documents as JSON."),
+    ] = False,
 ) -> None:
     """List ingested documents."""
 
     async def run() -> None:
         container = await build_ingest_container()
         documents = await container.repository.list(limit=limit, offset=offset)
+        if json_output:
+            console.out(
+                json.dumps(
+                    {
+                        "documents": [
+                            {
+                                "id": str(document.id),
+                                "status": document.status.value,
+                                "filename": document.source.filename,
+                                "byte_size": document.source.byte_size,
+                            }
+                            for document in documents
+                        ],
+                        "limit": limit,
+                        "offset": offset,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return
         table = Table("ID", "Status", "Filename", "Bytes")
         for document in documents:
             table.add_row(
@@ -1002,6 +1066,10 @@ def list_documents(
 @app.command()
 def show(
     document_id: Annotated[str, typer.Argument(help="Document ID to inspect.")],
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print metadata as JSON."),
+    ] = False,
 ) -> None:
     """Show document metadata and latest output summary."""
 
@@ -1012,6 +1080,33 @@ def show(
             raise typer.BadParameter(f"Document not found: {document_id}")
         output = await container.repository.get_cleaned_output(DocumentId(document_id))
         classification = await container.repository.get_classification(DocumentId(document_id))
+        if json_output:
+            console.out(
+                json.dumps(
+                    {
+                        "document_id": str(document.id),
+                        "status": document.status.value,
+                        "source": str(document.source.path),
+                        "filename": document.source.filename,
+                        "byte_size": document.source.byte_size,
+                        "classification": (
+                            {
+                                "code": classification.code,
+                                "label": classification.label,
+                                "title": classification.title,
+                                "tags": list(classification.tags),
+                                "summary": classification.summary,
+                            }
+                            if classification
+                            else None
+                        ),
+                        "cleaned_chars": len(output.text) if output else None,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return
         console.print(f"ID: {document.id}")
         console.print(f"Status: {document.status.value}")
         console.print(f"Source: {document.source.path}")
@@ -1062,6 +1157,10 @@ def status(
         int,
         typer.Option(help="Run events to skip.", min=0),
     ] = 0,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print run status and events as JSON."),
+    ] = False,
 ) -> None:
     """Show processing run status and events."""
 
@@ -1070,12 +1169,32 @@ def status(
         run_record = await container.repository.get_run(RunId(run_id))
         if run_record is None:
             raise typer.BadParameter(f"Run not found: {run_id}")
-        console.print(f"Run {run_record.id}: {run_record.status.value} ({run_record.stage.value})")
-        for event in await container.repository.list_events(
+        events = await container.repository.list_events(
             run_record.id,
             limit=event_limit,
             offset=event_offset,
-        ):
+        )
+        if json_output:
+            console.out(
+                json.dumps(
+                    {
+                        "run_id": str(run_record.id),
+                        "document_id": str(run_record.document_id),
+                        "status": run_record.status.value,
+                        "stage": run_record.stage.value,
+                        "total_chunks": run_record.total_chunks,
+                        "completed_chunks": run_record.completed_chunks,
+                        "failed_chunks": run_record.failed_chunks,
+                        "error": run_record.error,
+                        "events": list(events),
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return
+        console.print(f"Run {run_record.id}: {run_record.status.value} ({run_record.stage.value})")
+        for event in events:
             console.print(event)
 
     asyncio.run(run())
@@ -1122,6 +1241,10 @@ def search(
         str,
         typer.Option(help="Search cleaned outputs or raw extracted source text."),
     ] = "cleaned",
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print results as JSON (IDs, or full records with --details)."),
+    ] = False,
 ) -> None:
     """Search cleaned outputs."""
 
@@ -1159,6 +1282,46 @@ def search(
                 )
             except ValueError as exc:
                 raise typer.BadParameter(sanitize_error_message(exc)) from exc
+            if json_output:
+                console.out(
+                    json.dumps(
+                        {
+                            "total": total,
+                            "limit": limit,
+                            "offset": offset,
+                            "results": [
+                                {
+                                    "document_id": str(result.document_id),
+                                    "source": result.source,
+                                    "run_id": str(result.run_id) if result.run_id else None,
+                                    "document_status": result.document_status.value,
+                                    "created_at": result.created_at.isoformat(),
+                                    "classification_code": result.classification_code,
+                                    "classification_label": result.classification_label,
+                                    "score": result.score,
+                                    "snippet": result.snippet,
+                                    "transcript_citation": (
+                                        {
+                                            "matched_text": result.transcript_citation.matched_text,
+                                            "start_seconds": (
+                                                result.transcript_citation.start_seconds
+                                            ),
+                                            "end_seconds": result.transcript_citation.end_seconds,
+                                            "strategy": result.transcript_citation.strategy,
+                                            "confidence": result.transcript_citation.confidence,
+                                        }
+                                        if result.transcript_citation
+                                        else None
+                                    ),
+                                }
+                                for result in results
+                            ],
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    )
+                )
+                return
             console.print(
                 f"Showing {len(results)} of {total} results (offset={offset}, limit={limit})"
             )
@@ -1217,6 +1380,19 @@ def search(
             )
         except ValueError as exc:
             raise typer.BadParameter(sanitize_error_message(exc)) from exc
+        if json_output:
+            console.out(
+                json.dumps(
+                    {
+                        "document_ids": [str(document_id) for document_id in ids],
+                        "limit": limit,
+                        "offset": offset,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return
         for document_id in ids:
             console.print(document_id)
 

--- a/src/librarian/version.py
+++ b/src/librarian/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,6 +93,62 @@ def test_cli_doctor_json_emits_machine_readable_checks(tmp_path: Path) -> None:
     assert all({"name", "capability", "status", "detail"} <= set(c) for c in payload["checks"])
 
 
+def test_cli_json_drives_full_processing_loop(tmp_path: Path) -> None:
+    """An agent must be able to drive ingest -> process -> query entirely from JSON."""
+    runner = CliRunner()
+    env = {
+        "LIBRARIAN_DATA_DIR": str(tmp_path / ".librarian"),
+        "LIBRARIAN_DATABASE_PATH": str(tmp_path / ".librarian" / "librarian.sqlite"),
+    }
+    source = tmp_path / "note.txt"
+    source.write_text(
+        "A horse training transcript about a colt and groundwork with saddle fit.",
+        encoding="utf-8",
+    )
+
+    ingested = runner.invoke(app, ["ingest", str(source), "--json"], env=env)
+    assert ingested.exit_code == 0, ingested.output
+    ingest_payload = json.loads(_strip_ansi(ingested.output))
+    document_id = ingest_payload["document_id"]
+    assert ingest_payload["duplicate"] is False
+    assert ingest_payload["extracted_chars"] > 0
+
+    processed = runner.invoke(app, ["process", document_id, "--json"], env=env)
+    assert processed.exit_code == 0, processed.output
+    process_payload = json.loads(_strip_ansi(processed.output))
+    run_id = process_payload["run_id"]
+    assert process_payload["status"] == "succeeded"
+    assert process_payload["total_chunks"] == process_payload["completed_chunks"]
+
+    listed = json.loads(_strip_ansi(runner.invoke(app, ["list", "--json"], env=env).output))
+    assert document_id in {doc["id"] for doc in listed["documents"]}
+
+    shown = json.loads(
+        _strip_ansi(runner.invoke(app, ["show", document_id, "--json"], env=env).output)
+    )
+    assert shown["document_id"] == document_id
+    assert shown["classification"]["code"]
+    assert shown["cleaned_chars"] > 0
+
+    status = json.loads(
+        _strip_ansi(runner.invoke(app, ["status", run_id, "--json"], env=env).output)
+    )
+    assert status["run_id"] == run_id
+    assert status["status"] == "succeeded"
+    assert isinstance(status["events"], list) and status["events"]
+
+    ids = json.loads(_strip_ansi(runner.invoke(app, ["search", "horse", "--json"], env=env).output))
+    assert document_id in ids["document_ids"]
+
+    detailed = json.loads(
+        _strip_ansi(
+            runner.invoke(app, ["search", "horse", "--json", "--details"], env=env).output
+        )
+    )
+    assert detailed["results"][0]["document_id"] == document_id
+    assert detailed["results"][0]["classification_code"]
+
+
 def test_cli_doctor_strict_fails_when_optional_dependencies_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -74,7 +74,7 @@ def test_release_docs_describe_stable_surface() -> None:
     operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Version `1.3.0` is the stable production release." in readme
+    assert "Version `1.4.0` is the stable production release." in readme
     assert "librarian admin page-manifest" in operations
     assert "librarian maintainer eval" in operations
     assert "## 1.0.0 - 2026-05-22" in changelog

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ wheels = [
 
 [[package]]
 name = "nampara-librarian"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Makes the CLI fully scriptable so an agent can drive bulk document processing end to end without scraping human-readable tables. Cut as **v1.4.0** (additive feature).

### Audit result
Already agent-grade: `import` (`--recursive`, `--process`/`--queue`, `--manifest`/`--resume` for idempotent bulk, `--report` JSON file, non-zero exit on failure), SHA-based ingest de-dup, and `--json` on `doctor`/`admin db-stats`/`admin api-audit`/`transcript-find`/`admin page-manifest`.

The gap: the commands an agent **polls and parses** — `ingest`, `process`, `status`, `list`, `show`, `search` — emitted only Rich tables/prose.

### Change
A consistent `--json` flag on those six, emitting clean **unstyled** JSON (`console.out(json.dumps(..., indent=2, sort_keys=True))`, matching the existing convention):

| Command | JSON payload |
|---|---|
| `ingest --json` | `document_id`, `filename`, `extracted_chars`, `duplicate` |
| `process --json` | `run_id`, `document_id`, `status`, `stage`, `total_chunks`, `completed_chunks`, `failed_chunks` |
| `status --json` | run fields above + `error` + `events[]` (for polling to completion) |
| `list --json` | `documents[]` (`id`, `status`, `filename`, `byte_size`), `limit`, `offset` |
| `show --json` | document metadata + `classification` (code, label, **title, tags, summary**) + `cleaned_chars` |
| `search --json` | `document_ids[]`; with `--details`: full `results[]` (score, snippet, classification, transcript citation) |

Human output is unchanged when `--json` is omitted.

### Validation
- New test `test_cli_json_drives_full_processing_loop` drives `ingest → process → list → show → status → search [--details]` entirely by parsing JSON, asserting the IDs thread through and key fields are present (mock provider, no credentials).
- Live-smoked all six end to end (output piped through `python -c json.load`).
- `ruff` clean, `pyright` strict 0 errors, **497 passed / 3 skipped**, changelog ready for v1.4.0.
- README gains an "Automation and scripting" section documenting the agent flow.

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_