### PR TITLE
Open Knowledge Format (OKF) v0.1 bundle export (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.5.0 - 2026-06-14
+
+Librarian can now emit a processed corpus as an Open Knowledge Format (OKF) v0.1 bundle — a
+vendor-neutral, agent- and human-readable knowledge format
+([spec](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)). Turn a pile of
+scanned PDFs, transcripts, and documents into a portable knowledge wiki an agent can reason over.
+
+- New `librarian export-okf ./bundle` (and `GET /export/okf`, `GET /documents/{id}/okf`) render
+  processed documents as conformant OKF concept files: markdown with YAML frontmatter, organized
+  into a Dewey-derived directory hierarchy, cross-linked to same-classification siblings, and
+  accompanied by generated `index.md` files for progressive disclosure. The bundle root declares
+  `okf_version: "0.1"`. Filters: `--classification-prefix`, `--tag`, `--limit`; `--json` summary;
+  non-zero exit when nothing matches.
+- The classification stage now also produces a one-sentence `description` (the new `dewey_v4`
+  prompt), used as the OKF concept abstract; documents classified before v4 fall back to the first
+  sentence of their synopsis. Frontmatter maps title → `title`, the one-line abstract →
+  `description`, tags → `tags`, the document kind → `type`, with the Dewey code/label and
+  confidence as extension fields. There is no runtime OKF dependency — Librarian emits the format
+  directly. See [docs/OKF.md](docs/OKF.md).
+- A Mac-app "Markdown (OKF bundle)" output format is a planned fast follow.
+
 ## 1.4.0 - 2026-06-13
 
 Makes the CLI fully scriptable, so an agent can drive bulk document processing end to end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Librarian is a local-first document ingestion, cleaning, classification, and search system. It converts transcripts, Markdown, text files, DOCX, PDFs, and OCR images into clean Markdown or plain text; processes them with an OpenAI-compatible model while preserving source fidelity; classifies the result with Dewey-style labels; and exposes the same engine through a Mac app, a CLI, and a FastAPI service.
 
-Version `1.4.0` is the stable production release. The default deployment is local or single-node: source documents and generated outputs stay in SQLite-backed local storage unless you configure an external model provider for cleaning, classification, or OCR correction.
+Version `1.5.0` is the stable production release. The default deployment is local or single-node: source documents and generated outputs stay in SQLite-backed local storage unless you configure an external model provider for cleaning, classification, or OCR correction.
 
 ## Mac App
 
@@ -34,7 +34,7 @@ From a downloaded release wheel:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install "nampara_librarian-1.4.0-py3-none-any.whl[all]"
+pip install "nampara_librarian-1.5.0-py3-none-any.whl[all]"
 ```
 
 From a source checkout:
@@ -117,6 +117,7 @@ librarian delete doc_... --yes
 librarian status run_... --event-limit 500 --event-offset 0
 librarian search "horse training" --details
 librarian export doc_... --format json --citation-quote "quoted source phrase"
+librarian export-okf ./bundle --classification-prefix 6 --json
 librarian api
 ```
 
@@ -125,6 +126,8 @@ librarian api
 ### Automation and scripting
 
 The query and control commands emit machine-readable JSON with `--json`, so an agent can drive the whole pipeline without scraping tables: `ingest --json` and `process --json` return the new `document_id`/`run_id`; `status --json` reports `status`, `stage`, `total_chunks`, and `completed_chunks` for polling; and `list`, `show`, and `search [--details] --json` return structured records. For bulk runs, `librarian import --recursive --process --report report.json` writes a full JSON report, `--manifest <path> --resume` makes large imports idempotent across restarts, and the command exits non-zero if any item failed. `doctor --json`, `admin db-stats --json`, `admin api-audit --json`, and `admin page-manifest --json` round out the machine-readable surface.
+
+To hand a processed corpus to another agent or knowledge tool, `librarian export-okf ./bundle` renders all processed documents as an [Open Knowledge Format](docs/OKF.md) v0.1 bundle — a directory of markdown concept files with YAML frontmatter, organized by Dewey classification, cross-linked, and indexed. See [docs/OKF.md](docs/OKF.md) for the field mapping and layout.
 
 Operator commands live under `librarian admin`, including database maintenance, backups, run controls, queue inspection, API audit logs, and PDF page-manifest inspection. Release and quality harnesses live under `librarian maintainer`; they ship with source checkouts only and are excluded from release wheels.
 
@@ -142,6 +145,7 @@ Primary endpoints:
 - `POST /runs`, `GET /runs`, `GET /runs/{id}`, `POST /runs/{id}/cancel`, `POST /runs/{id}/retry`
 - `GET /runs/{id}/events`, `GET /runs/{id}/events/stream`
 - `GET /documents/{id}/content`, `GET /documents/{id}/export?format=json|txt|md`
+- `GET /export/okf`, `GET /documents/{id}/okf` (Open Knowledge Format bundle / single concept)
 - `POST /search`, `POST /search/results`, `POST /search/facets`
 - `GET /metrics`, `GET /metrics/prometheus`
 
@@ -153,7 +157,7 @@ Containerized deployment is optional and aimed at server installs; the Mac app a
 
 ## Architecture And Operations
 
-Start with [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). API details are in [docs/API.md](docs/API.md), deployment guidance is in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md), and production runbooks are in [docs/OPERATIONS.md](docs/OPERATIONS.md).
+Start with [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). API details are in [docs/API.md](docs/API.md), deployment guidance is in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md), production runbooks are in [docs/OPERATIONS.md](docs/OPERATIONS.md), and the Open Knowledge Format export is documented in [docs/OKF.md](docs/OKF.md).
 
 ## Privacy
 

--- a/apps/macos/Support/Info.plist
+++ b/apps/macos/Support/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleIconFile</key>

--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,13 @@ Requests above `LIBRARIAN_API_MAX_REQUEST_BYTES` are rejected before routing, ei
   `citation_quote` when the original source is a timestamped transcript to include optional
   quote-grounded `transcript_citation` evidence in JSON and Markdown exports. Unsupported `format`
   values return `code: "bad_request"` before document lookup.
+- `GET /export/okf?classification_prefix=&tag=&limit=`: render all processed documents as an
+  [Open Knowledge Format](OKF.md) v0.1 bundle. Returns `{ "okf_version", "files": {path: content},
+  "skipped": [ids] }` where `files` is the complete bundle (concept markdown + generated
+  `index.md` files), organized by Dewey classification. Documents without a cleaned output and
+  classification are listed in `skipped`.
+- `GET /documents/{id}/okf`: the single OKF concept for one processed document as
+  `{ "path", "content" }`; `404` if the document is missing or not yet processed.
 
 ## Imports
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ import root:
 docker run --rm -p 8080:8080 \
   -e LIBRARIAN_API_KEY=change-me \
   -e LIBRARIAN_API_IMPORT_ROOT=/data/imports \
-  ghcr.io/nampara-ai/librarian:v1.4.0
+  ghcr.io/nampara-ai/librarian:v1.5.0
 ```
 
 ## Environment

--- a/docs/OKF.md
+++ b/docs/OKF.md
@@ -1,0 +1,87 @@
+# Open Knowledge Format (OKF) export
+
+Librarian can render a processed corpus as an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+v0.1 bundle: a vendor-neutral directory of markdown "concept" files with YAML
+frontmatter that any OKF-aware agent or tool can consume without a translation
+layer. This turns a pile of cleaned documents into a portable, navigable
+knowledge bundle.
+
+OKF is a format, not a dependency — there is no SDK to install. Librarian emits
+conformant bundles directly; it pins the version it targets via
+`okf_version: "0.1"` in the bundle-root `index.md`.
+
+## Producing a bundle
+
+CLI (for agents and bulk runs):
+
+```bash
+librarian export-okf ./bundle              # all processed documents
+librarian export-okf ./bundle --classification-prefix 6   # only Dewey 6xx
+librarian export-okf ./bundle --tag horses --limit 50 --json
+```
+
+`export-okf` includes only documents that have been processed (have a cleaned
+output and a classification); unprocessed documents are reported as skipped. The
+command exits non-zero when no documents match.
+
+HTTP:
+
+- `GET /export/okf?classification_prefix=&tag=&limit=` → `{ "okf_version", "files": {path: content}, "skipped": [...] }`
+- `GET /documents/{id}/okf` → `{ "path", "content" }` for a single concept
+
+## Bundle layout
+
+Documents are placed into a directory tree derived from their Dewey
+classification, so the directory structure doubles as a browsable taxonomy:
+
+```
+index.md                                  # bundle root; declares okf_version
+600-technology/
+  index.md
+  630-agriculture/
+    636-animal-husbandry/
+      636-1-horses-equines/
+        index.md
+        saddle-fit-and-groundwork-notes.md
+```
+
+- The **concept ID** is the file path minus `.md` (per the spec).
+- Each directory gets an `index.md` listing its concepts and subsections for
+  progressive disclosure. Only the bundle-root `index.md` carries frontmatter
+  (the `okf_version` declaration), as the spec requires.
+- Concepts that share a Dewey code are cross-linked under a `## Related`
+  section, forming a graph richer than the directory tree.
+
+## Field mapping
+
+Each concept's frontmatter is rendered from Librarian's classification and
+document metadata:
+
+| OKF field | Source | Notes |
+| --- | --- | --- |
+| `type` (required) | source document kind | e.g. `PDF Document`, `Transcript`, `Word Document`, `Scanned Image`, else `Document` |
+| `title` | classification title | falls back to the source filename stem |
+| `description` | classification one-sentence abstract | falls back to the first sentence of the synopsis |
+| `resource` | `urn:librarian:doc:{id}` | stable, portable identity (not a local path) |
+| `tags` | classification tags | |
+| `timestamp` | cleaned-output creation time | ISO-8601 UTC |
+| `dewey_code` / `dewey_label` | classification | extension fields |
+| `source_filename` | original filename | extension field |
+| `classification_confidence` | classification confidence | extension field |
+
+The body is the cleaned markdown, preceded by the full synopsis as a blockquote.
+
+## Conformance
+
+A bundle is OKF v0.1 conformant if every non-reserved `.md` file has a parseable
+YAML frontmatter block with a non-empty `type`. Librarian guarantees this for
+every concept it emits; the test suite parses every emitted file and asserts it.
+Everything else in the spec is advisory, and consumers must tolerate missing
+optional fields, unknown types, and broken links.
+
+## Versioning
+
+OKF is versioned with a backward-compatible growth promise. Librarian targets
+**v0.1** today and declares it in the bundle root. If the upstream spec
+revises, the producer is updated in a contained change and the declared version
+is bumped accordingly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nampara-librarian"
-version = "1.4.0"
+version = "1.5.0"
 description = "Local-first corpus cleaner and library organizer with CLI and API surfaces."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -75,6 +75,10 @@ dev = [
   "httpx2>=2.3.0",
   "pip-audit>=2.9.0",
   "urllib3>=2.7.0",
+  # Tests parse emitted OKF frontmatter to assert bundle conformance; the OKF
+  # producer itself emits YAML with no runtime dependency.
+  "pyyaml>=6.0",
+  "types-pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -40,6 +40,12 @@ from librarian.application.export_document import (
     ExportFormat,
     transcript_citation_for_document,
 )
+from librarian.application.export_okf import (
+    OKF_VERSION,
+    OkfSource,
+    build_bundle,
+    collect_sources,
+)
 from librarian.application.factory import build_container, build_ingest_container
 from librarian.application.import_library import ImportLibrary, ImportProcessingMode
 from librarian.application.jobs import InProcessJobRunner
@@ -269,6 +275,17 @@ class ExportDocumentResponse(BaseModel):
     suggested_stem: str
     text: str
     transcript_citation: SearchTranscriptCitationResponse | None = None
+
+
+class OkfBundleResponse(BaseModel):
+    okf_version: str
+    files: dict[str, str]
+    skipped: list[str]
+
+
+class OkfConceptResponse(BaseModel):
+    path: str
+    content: str
 
 
 class SearchRequest(BaseModel):
@@ -1108,6 +1125,39 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             transcript_citation=transcript_citation,
         )
         return _export_response(exported, export_format)
+
+    @app.get("/export/okf", response_model=OkfBundleResponse)
+    async def export_okf_bundle(
+        classification_prefix: str | None = None,
+        tag: str | None = None,
+        limit: Annotated[int | None, Query(ge=1, le=100_000)] = None,
+    ) -> OkfBundleResponse:
+        container = await build_ingest_container(settings)
+        sources, skipped = await collect_sources(
+            container.repository,
+            classification_prefix=classification_prefix,
+            tag=tag,
+            limit=limit,
+        )
+        files = build_bundle(sources, taxonomy=container.taxonomy)
+        return OkfBundleResponse(okf_version=OKF_VERSION, files=files, skipped=skipped)
+
+    @app.get("/documents/{document_id}/okf", response_model=OkfConceptResponse)
+    async def export_okf_concept(document_id: str) -> OkfConceptResponse:
+        container = await build_ingest_container(settings)
+        document = await container.repository.get_document(DocumentId(document_id))
+        if document is None:
+            raise HTTPException(status_code=404, detail="Document not found")
+        output = await container.repository.get_cleaned_output(DocumentId(document_id))
+        classification = await container.repository.get_classification(DocumentId(document_id))
+        if output is None or classification is None:
+            raise HTTPException(status_code=404, detail="Document is not processed yet")
+        files = build_bundle(
+            [OkfSource(document=document, output=output, classification=classification)],
+            taxonomy=container.taxonomy,
+        )
+        concept_path = next(path for path in files if not path.endswith("index.md"))
+        return OkfConceptResponse(path=concept_path, content=files[concept_path])
 
     @app.post("/runs", response_model=RunResponse)
     async def create_run(request: RunRequest, http_request: Request) -> RunResponse:

--- a/src/librarian/application/classify_document.py
+++ b/src/librarian/application/classify_document.py
@@ -28,11 +28,13 @@ class ClassificationPayload(BaseModel):
     confidence: float | None = None
     title: str | None = None
     tags: list[str] = []
+    description: str | None = None
 
 
 _MAX_TAGS = 8
 _MAX_TAG_CHARS = 60
 _MAX_TITLE_CHARS = 120
+_MAX_DESCRIPTION_CHARS = 280
 
 
 def _clean_title(value: str | None) -> str | None:
@@ -40,6 +42,13 @@ def _clean_title(value: str | None) -> str | None:
         return None
     collapsed = " ".join(value.split())
     return collapsed[:_MAX_TITLE_CHARS].strip() or None
+
+
+def _clean_description(value: str | None) -> str | None:
+    if value is None:
+        return None
+    collapsed = " ".join(value.split())
+    return collapsed[:_MAX_DESCRIPTION_CHARS].strip() or None
 
 
 def _clean_tags(values: list[str]) -> tuple[str, ...]:
@@ -103,6 +112,7 @@ class ClassifyDocument:
             confidence=payload.confidence,
             title=_clean_title(payload.title),
             tags=_clean_tags(payload.tags),
+            description=_clean_description(payload.description),
         )
 
 

--- a/src/librarian/application/export_okf.py
+++ b/src/librarian/application/export_okf.py
@@ -1,0 +1,374 @@
+"""Render processed documents as an Open Knowledge Format (OKF) v0.1 bundle.
+
+OKF spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf
+
+A bundle is a directory of markdown "concept" files, each with a YAML
+frontmatter block and a markdown body. Here, concepts are organized into a
+Dewey-derived directory hierarchy, cross-linked to same-classification
+siblings, and accompanied by generated ``index.md`` files for progressive
+disclosure. The spec's only hard requirements are that every non-reserved
+``.md`` file has a parseable frontmatter block containing a non-empty ``type``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol, cast
+
+from librarian.application.ports import TaxonomyProvider
+from librarian.domain.ids import DocumentId
+from librarian.domain.models import Classification, CleanedOutput, Document
+
+OKF_VERSION = "0.1"
+
+_MAX_RELATED = 12
+_MAX_DESCRIPTION_CHARS = 280
+
+# Source extension -> OKF `type` (the "kind of concept", not its subject).
+_TYPE_BY_EXTENSION = {
+    "pdf": "PDF Document",
+    "docx": "Word Document",
+    "doc": "Word Document",
+    "md": "Markdown Document",
+    "markdown": "Markdown Document",
+    "txt": "Text Document",
+    "srt": "Transcript",
+    "vtt": "Transcript",
+    "png": "Scanned Image",
+    "jpg": "Scanned Image",
+    "jpeg": "Scanned Image",
+    "tif": "Scanned Image",
+    "tiff": "Scanned Image",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class OkfSource:
+    """One processed document to render into the bundle."""
+
+    document: Document
+    output: CleanedOutput
+    classification: Classification
+
+
+class OkfRepository(Protocol):
+    """The repository surface needed to assemble a bundle."""
+
+    async def list(self, *, limit: int = ..., offset: int = ...) -> Sequence[Document]: ...
+
+    async def get_cleaned_output(self, document_id: DocumentId) -> CleanedOutput | None: ...
+
+    async def get_classification(self, document_id: DocumentId) -> Classification | None: ...
+
+
+async def collect_sources(
+    repository: OkfRepository,
+    *,
+    classification_prefix: str | None = None,
+    tag: str | None = None,
+    limit: int | None = None,
+) -> tuple[list[OkfSource], list[str]]:
+    """Gather processed documents (with output + classification) for a bundle.
+
+    Returns the included sources and the ids of documents skipped because they
+    have not been processed (no cleaned output or classification yet). Documents
+    excluded by the prefix/tag filters are not counted as skipped.
+    """
+    sources: list[OkfSource] = []
+    skipped: list[str] = []
+    wanted_tag = tag.lower() if tag else None
+    page = 200
+    offset = 0
+    while True:
+        documents = await repository.list(limit=page, offset=offset)
+        if not documents:
+            break
+        for document in documents:
+            output = await repository.get_cleaned_output(document.id)
+            classification = await repository.get_classification(document.id)
+            if output is None or classification is None:
+                skipped.append(str(document.id))
+                continue
+            if classification_prefix and not classification.code.startswith(classification_prefix):
+                continue
+            if wanted_tag and wanted_tag not in {t.lower() for t in classification.tags}:
+                continue
+            sources.append(
+                OkfSource(document=document, output=output, classification=classification)
+            )
+            if limit is not None and len(sources) >= limit:
+                return sources, skipped
+        if len(documents) < page:
+            break
+        offset += page
+    return sources, skipped
+
+
+@dataclass(frozen=True, slots=True)
+class _Concept:
+    path: str  # bundle-relative, e.g. "600-technology/636-1-horses-equines/notes.md"
+    code: str
+    type: str
+    title: str
+    description: str | None
+    resource: str
+    tags: tuple[str, ...]
+    timestamp: str
+    dewey_label: str
+    source_filename: str
+    confidence: float | None
+    summary: str
+    body: str
+
+
+def build_bundle(sources: list[OkfSource], *, taxonomy: TaxonomyProvider) -> dict[str, str]:
+    """Render the sources into a map of bundle-relative path -> file content."""
+    concepts: list[_Concept] = []
+    by_code: dict[str, list[_Concept]] = defaultdict(list)
+    dir_labels: dict[str, str] = {}
+    used_paths: set[str] = set()
+
+    for source in sources:
+        concept = _build_concept(source, taxonomy=taxonomy, dir_labels=dir_labels, used=used_paths)
+        used_paths.add(concept.path)
+        concepts.append(concept)
+        by_code[concept.code].append(concept)
+
+    files: dict[str, str] = {}
+    for concept in concepts:
+        related = [
+            (other.title, "/" + other.path)
+            for other in by_code[concept.code]
+            if other.path != concept.path
+        ][:_MAX_RELATED]
+        files[concept.path] = _render_concept(concept, related)
+
+    files.update(_build_indexes(concepts, dir_labels))
+    return files
+
+
+def _build_concept(
+    source: OkfSource,
+    *,
+    taxonomy: TaxonomyProvider,
+    dir_labels: dict[str, str],
+    used: set[str],
+) -> _Concept:
+    classification = source.classification
+    code = classification.code.strip() or "000"
+    label = classification.label.strip() or taxonomy.label_for(code) or "General"
+
+    segments: list[str] = []
+    for level_code, level_label in _dewey_hierarchy(code, taxonomy):
+        # The deepest level is the document's own code; fall back to its
+        # classification label when the taxonomy has no label for it.
+        effective_label = level_label or (label if level_code == code else None)
+        if effective_label:
+            segment = f"{_slug(level_code)}-{_slug(effective_label)}"
+        else:
+            segment = _slug(level_code)
+        segments.append(segment)
+        dir_labels["/".join(segments)] = effective_label or level_code
+    directory = "/".join(segments) or _slug(code)
+
+    stem = classification.title or _strip_extension(source.document.source.filename)
+    filename = _unique_filename(directory, _slug(stem, fallback="document"), used)
+    path = f"{directory}/{filename}.md"
+
+    description = classification.description or _first_sentence(classification.summary)
+
+    return _Concept(
+        path=path,
+        code=code,
+        type=_concept_type(source.document.source.filename),
+        title=stem or "Untitled",
+        description=description,
+        resource=f"urn:librarian:doc:{source.document.id}",
+        tags=tuple(classification.tags),
+        timestamp=source.output.created_at.isoformat().replace("+00:00", "Z"),
+        dewey_label=label,
+        source_filename=source.document.source.filename,
+        confidence=classification.confidence,
+        summary=classification.summary,
+        body=source.output.text,
+    )
+
+
+def _render_concept(concept: _Concept, related: list[tuple[str, str]]) -> str:
+    frontmatter = _frontmatter(
+        [
+            ("type", concept.type),
+            ("title", concept.title),
+            ("description", concept.description),
+            ("resource", concept.resource),
+            ("tags", list(concept.tags)),
+            ("timestamp", concept.timestamp),
+            ("dewey_code", concept.code),
+            ("dewey_label", concept.dewey_label),
+            ("source_filename", concept.source_filename),
+            ("classification_confidence", concept.confidence),
+        ]
+    )
+    parts = [frontmatter, ""]
+    summary = " ".join(concept.summary.split())
+    if summary:
+        parts.extend([f"> {summary}", ""])
+    parts.append(concept.body.strip())
+    if related:
+        parts.extend(["", "## Related", ""])
+        parts.extend(f"- [{title}]({link})" for title, link in related)
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _build_indexes(concepts: list[_Concept], dir_labels: dict[str, str]) -> dict[str, str]:
+    # Map each directory to its immediate child concepts and child subdirectories.
+    child_concepts: dict[str, list[_Concept]] = defaultdict(list)
+    child_dirs: dict[str, set[str]] = defaultdict(set)
+    all_dirs: set[str] = {""}
+
+    for concept in concepts:
+        directory = concept.path.rsplit("/", 1)[0]
+        child_concepts[directory].append(concept)
+        parts = directory.split("/")
+        for depth in range(len(parts)):
+            current = "/".join(parts[: depth + 1])
+            parent = "/".join(parts[:depth])
+            all_dirs.add(current)
+            child_dirs[parent].add(current)
+
+    files: dict[str, str] = {}
+    for directory in all_dirs:
+        index_path = f"{directory}/index.md" if directory else "index.md"
+        files[index_path] = _render_index(directory, dir_labels, child_concepts, child_dirs)
+    return files
+
+
+def _render_index(
+    directory: str,
+    dir_labels: dict[str, str],
+    child_concepts: dict[str, list[_Concept]],
+    child_dirs: dict[str, set[str]],
+) -> str:
+    lines: list[str] = []
+    if directory == "":
+        # Only the bundle-root index may carry frontmatter; declare the version.
+        lines.extend(["---", f'okf_version: "{OKF_VERSION}"', "---", ""])
+        title = "Librarian Knowledge Bundle"
+    else:
+        title = dir_labels.get(directory, directory.rsplit("/", 1)[-1])
+    lines.append(f"# {title}")
+
+    subdirs = sorted(child_dirs.get(directory, set()))
+    if subdirs:
+        lines.extend(["", "## Sections"])
+        for subdir in subdirs:
+            label = dir_labels.get(subdir, subdir.rsplit("/", 1)[-1])
+            count = _concept_count(subdir, child_concepts, child_dirs)
+            lines.append(f"- [{label}](/{subdir}/index.md) — {count} concept(s)")
+
+    concepts = sorted(child_concepts.get(directory, []), key=lambda c: c.title.lower())
+    if concepts:
+        lines.extend(["", "## Concepts"])
+        for concept in concepts:
+            suffix = f" — {concept.description}" if concept.description else ""
+            lines.append(f"- [{concept.title}](/{concept.path}){suffix}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _concept_count(
+    directory: str,
+    child_concepts: dict[str, list[_Concept]],
+    child_dirs: dict[str, set[str]],
+) -> int:
+    total = len(child_concepts.get(directory, []))
+    for subdir in child_dirs.get(directory, set()):
+        total += _concept_count(subdir, child_concepts, child_dirs)
+    return total
+
+
+def _dewey_hierarchy(code: str, taxonomy: TaxonomyProvider) -> list[tuple[str, str | None]]:
+    """Derive ancestor codes (class, division, section, full) for a Dewey code."""
+    digits = "".join(char for char in code if char.isdigit())
+    candidates: list[str] = []
+    if digits:
+        candidates.append(digits[0] + "00")
+        if len(digits) >= 2:
+            candidates.append(digits[:2] + "0")
+        if len(digits) >= 3:
+            candidates.append(digits[:3])
+    if code and code not in candidates:
+        candidates.append(code)
+
+    hierarchy: list[tuple[str, str | None]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            hierarchy.append((candidate, taxonomy.label_for(candidate)))
+    if not hierarchy:
+        fallback = code or "000"
+        hierarchy.append((fallback, taxonomy.label_for(fallback)))
+    return hierarchy
+
+
+def _concept_type(filename: str) -> str:
+    extension = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    return _TYPE_BY_EXTENSION.get(extension, "Document")
+
+
+def _strip_extension(filename: str) -> str:
+    return filename.rsplit(".", 1)[0] if "." in filename else filename
+
+
+def _first_sentence(text: str) -> str | None:
+    collapsed = " ".join(text.split())
+    if not collapsed:
+        return None
+    match = re.search(r".+?[.!?](?:\s|$)", collapsed)
+    sentence = (match.group(0) if match else collapsed).strip()
+    return sentence[:_MAX_DESCRIPTION_CHARS].strip() or None
+
+
+def _slug(text: str, *, fallback: str = "untitled") -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+    return slug or fallback
+
+
+def _unique_filename(directory: str, stem: str, used: set[str]) -> str:
+    candidate = stem
+    counter = 2
+    while f"{directory}/{candidate}.md" in used:
+        candidate = f"{stem}-{counter}"
+        counter += 1
+    return candidate
+
+
+def _frontmatter(fields: list[tuple[str, object]]) -> str:
+    lines = ["---"]
+    for key, value in fields:
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            lines.append(f"{key}: {'true' if value else 'false'}")
+        elif isinstance(value, (int, float)):
+            lines.append(f"{key}: {value}")
+        elif isinstance(value, (list, tuple)):
+            items = cast(Sequence[object], value)
+            if not items:
+                continue
+            rendered = ", ".join(_yaml_quote(str(item)) for item in items)
+            lines.append(f"{key}: [{rendered}]")
+        else:
+            lines.append(f"{key}: {_yaml_quote(str(value))}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _yaml_quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    escaped = escaped.replace("\n", " ").replace("\t", " ")
+    return f'"{escaped}"'

--- a/src/librarian/application/factory.py
+++ b/src/librarian/application/factory.py
@@ -30,6 +30,7 @@ class IngestContainer:
     repository: SQLiteRepository
     ingest_document: IngestDocument
     search_library: SearchLibrary
+    taxonomy: DeweyTaxonomy
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +86,7 @@ async def build_ingest_container(
         repository=repository,
         ingest_document=ingest,
         search_library=SearchLibrary(repository),
+        taxonomy=DeweyTaxonomy(),
     )
 
 
@@ -108,7 +110,7 @@ async def build_container(
         max_parallel_chunks=resolved_settings.llm_max_concurrency,
         max_response_chars=resolved_settings.llm_max_response_chars,
     )
-    taxonomy = DeweyTaxonomy()
+    taxonomy = ingest_container.taxonomy
     classifier = ClassifyDocument(
         provider=provider,
         prompt_catalog=PromptCatalog(),
@@ -140,6 +142,7 @@ async def build_container(
         repository=repository,
         ingest_document=ingest_container.ingest_document,
         search_library=ingest_container.search_library,
+        taxonomy=ingest_container.taxonomy,
         process_document=process,
     )
 

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -31,6 +31,7 @@ from librarian.application.export_document import (
     ExportFormat,
     transcript_citation_for_document,
 )
+from librarian.application.export_okf import OKF_VERSION, build_bundle, collect_sources
 from librarian.application.factory import build_container, build_ingest_container
 from librarian.application.import_library import (
     ImportLibrary,
@@ -1440,6 +1441,75 @@ def export(
             console.print(rendered)
 
     asyncio.run(run())
+
+
+@app.command("export-okf")
+def export_okf(
+    bundle_dir: Annotated[
+        Path,
+        typer.Argument(help="Directory to write the Open Knowledge Format bundle into."),
+    ],
+    classification_prefix: Annotated[
+        str | None,
+        typer.Option(help="Only include documents whose Dewey code starts with this prefix."),
+    ] = None,
+    tag: Annotated[
+        str | None,
+        typer.Option(help="Only include documents carrying this tag."),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        typer.Option(help="Maximum number of documents to include.", min=1),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print a machine-readable summary."),
+    ] = False,
+) -> None:
+    """Export processed documents as an Open Knowledge Format (OKF) bundle."""
+
+    async def run() -> None:
+        container = await build_ingest_container()
+        sources, skipped = await collect_sources(
+            container.repository,
+            classification_prefix=classification_prefix,
+            tag=tag,
+            limit=limit,
+        )
+        files = build_bundle(sources, taxonomy=container.taxonomy)
+        target = bundle_dir.expanduser()
+        await asyncio.to_thread(_write_okf_bundle, target, files)
+        if json_output:
+            console.out(
+                json.dumps(
+                    {
+                        "bundle_path": str(target),
+                        "okf_version": OKF_VERSION,
+                        "concepts": len(sources),
+                        "files_written": len(files),
+                        "skipped": len(skipped),
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            console.print(
+                f"Wrote {len(sources)} concept(s) in {len(files)} file(s) to {target} "
+                f"(OKF v{OKF_VERSION}); skipped {len(skipped)} unprocessed document(s)."
+            )
+        if not sources:
+            raise typer.Exit(code=1)
+
+    asyncio.run(run())
+
+
+def _write_okf_bundle(target: Path, files: dict[str, str]) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    for relative_path, content in files.items():
+        destination = target / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
 
 
 _MAINTAINER_HARNESS_MISSING = (

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -16,7 +16,7 @@ LogFormatSetting = Literal["json", "text"]
 LogLevelSetting = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 LlmProviderSetting = Literal["mock", "openai-compatible"]
 CleaningPromptVersionSetting = Literal["cmos_v1", "cmos_v2"]
-ClassificationPromptVersionSetting = Literal["dewey_v1", "dewey_v2", "dewey_v3"]
+ClassificationPromptVersionSetting = Literal["dewey_v1", "dewey_v2", "dewey_v3", "dewey_v4"]
 CleaningModeSetting = Literal["standard"]
 
 
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     llm_max_response_chars: int = Field(default=2 * 1024 * 1024, gt=0)
 
     cleaning_prompt_version: CleaningPromptVersionSetting = Field(default="cmos_v2")
-    classification_prompt_version: ClassificationPromptVersionSetting = Field(default="dewey_v3")
+    classification_prompt_version: ClassificationPromptVersionSetting = Field(default="dewey_v4")
     cleaning_mode: CleaningModeSetting = Field(default="standard")
     coherence_mode: CoherenceModeSetting = Field(default="balanced")
 

--- a/src/librarian/domain/models.py
+++ b/src/librarian/domain/models.py
@@ -99,6 +99,7 @@ class Classification:
     confidence: float | None = None
     title: str | None = None
     tags: tuple[str, ...] = ()
+    description: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/librarian/llm/mock.py
+++ b/src/librarian/llm/mock.py
@@ -39,9 +39,11 @@ class MockLLMProvider:
             elif any(term in text for term in ("library", "catalog", "metadata", "search recall")):
                 code = "020"
                 label = "Library & Information Sciences"
+            summary_text = " ".join(user_prompt.split("Text to analyze:", 1)[-1].split())[:300]
             return json.dumps(
                 {
-                    "summary": " ".join(user_prompt.split("Text to analyze:", 1)[-1].split())[:300],
+                    "summary": summary_text,
+                    "description": f"A document about {label}.",
                     "dewey_code": code,
                     "category_name": label,
                     "title": f"{label} Notes",

--- a/src/librarian/prompts/classification/dewey_v4.md
+++ b/src/librarian/prompts/classification/dewey_v4.md
@@ -1,0 +1,51 @@
+Analyze the supplied text as a professional librarian.
+
+Return:
+1. A synopsis of 80 to 100 words describing what the content is about.
+2. A single-sentence description (25 words or fewer) summarizing the entire document — a concise
+   one-line abstract suitable for a catalog entry.
+3. The most appropriate Dewey Decimal Classification code.
+4. The matching category name.
+5. A short descriptive title for the document: 3 to 8 words in title case, specific to this
+   document's actual content, suitable for use as a filename. Use only letters, digits, spaces,
+   hyphens, ampersands, commas, and apostrophes.
+6. Between 3 and 7 topical tags: short lowercase phrases naming the document's subjects.
+7. A confidence score from 0.0 to 1.0.
+
+Respond with only valid JSON using this exact shape:
+
+{
+  "summary": "80-to-100-word synopsis",
+  "description": "one-sentence abstract of the whole document",
+  "dewey_code": "XXX.X",
+  "category_name": "Category Name",
+  "title": "Short Descriptive Title",
+  "tags": ["first tag", "second tag", "third tag"],
+  "confidence": 0.0
+}
+
+Choose the most specific code that fits the dominant subject matter. Prefer the text's actual topic
+over incidental examples, names, or metaphors. The title and description must describe this specific
+document, not just its category.
+
+Common Dewey codes for reference:
+- 000 = Computer Science & Information
+- 100 = Philosophy & Psychology
+- 200 = Religion
+- 300 = Social Sciences
+- 320 = Political Science
+- 330 = Economics
+- 340 = Law
+- 370 = Education
+- 400 = Language
+- 500 = Science
+- 600 = Technology
+- 610 = Medicine & Health
+- 630 = Agriculture
+- 636 = Animal Husbandry
+- 636.1 = Horses & Equines
+- 636.7 = Dogs
+- 636.8 = Cats
+- 700 = Arts & Recreation
+- 800 = Literature
+- 900 = History & Geography

--- a/src/librarian/storage/migrations/0007_classification_description.sql
+++ b/src/librarian/storage/migrations/0007_classification_description.sql
@@ -1,0 +1,1 @@
+ALTER TABLE classifications ADD COLUMN description TEXT;

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -2412,9 +2412,9 @@ def _cleaned_output_from_row(row: sqlite3.Row) -> CleanedOutput:
 
 _CLASSIFICATION_UPSERT_SQL = """
     INSERT INTO classifications (
-      document_id, code, label, summary, taxonomy, confidence, title, tags
+      document_id, code, label, summary, taxonomy, confidence, title, tags, description
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(document_id) DO UPDATE SET
       code = excluded.code,
       label = excluded.label,
@@ -2422,13 +2422,14 @@ _CLASSIFICATION_UPSERT_SQL = """
       taxonomy = excluded.taxonomy,
       confidence = excluded.confidence,
       title = excluded.title,
-      tags = excluded.tags
+      tags = excluded.tags,
+      description = excluded.description
 """
 
 
 def _classification_upsert_params(
     classification: Classification,
-) -> tuple[str, str, str, str, str, float | None, str | None, str]:
+) -> tuple[str, str, str, str, str, float | None, str | None, str, str | None]:
     return (
         str(classification.document_id),
         classification.code,
@@ -2438,6 +2439,7 @@ def _classification_upsert_params(
         classification.confidence,
         classification.title,
         json.dumps(list(classification.tags)),
+        classification.description,
     )
 
 
@@ -2456,6 +2458,7 @@ def _classification_tags_from_column(value: object) -> tuple[str, ...]:
 def _classification_from_row(row: sqlite3.Row) -> Classification:
     confidence = row["confidence"]
     title = row["title"]
+    description = row["description"]
     return Classification(
         document_id=DocumentId(str(row["document_id"])),
         code=str(row["code"]),
@@ -2465,6 +2468,7 @@ def _classification_from_row(row: sqlite3.Row) -> Classification:
         confidence=float(confidence) if confidence is not None else None,
         title=str(title) if title is not None else None,
         tags=_classification_tags_from_column(row["tags"]),
+        description=str(description) if description is not None else None,
     )
 
 

--- a/src/librarian/version.py
+++ b/src/librarian/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/tests/test_api_processing.py
+++ b/tests/test_api_processing.py
@@ -1430,7 +1430,7 @@ def test_api_config_exposes_operational_controls(tmp_path: Path) -> None:
     assert payload["ocr_preserve_page_images"] is True
     assert payload["ocr_rotation_retry"] is True
     assert payload["cleaning_prompt_version"] == "cmos_v2"
-    assert payload["classification_prompt_version"] == "dewey_v3"
+    assert payload["classification_prompt_version"] == "dewey_v4"
     assert payload["universal_timeout_seconds"] == 77
     assert payload["llm_max_retries"] == settings.llm_max_retries
     assert payload["api_auth_keys_configured"] == 0
@@ -2725,3 +2725,51 @@ def _wait_for_run(client: TestClient, run_id: str):
         sleep(0.05)
         response = client.get(f"/runs/{run_id}")
     return response
+
+
+def test_api_export_okf_bundle_and_concept(tmp_path: Path) -> None:
+    import yaml
+
+    settings = Settings(
+        data_dir=tmp_path / ".librarian",
+        database_path=tmp_path / ".librarian" / "librarian.sqlite",
+        chunk_target_chars=200,
+        chunk_overlap_chars=20,
+    )
+    with TestClient(create_app(settings)) as client:
+        upload = client.post(
+            "/documents",
+            files={
+                "file": (
+                    "horse.txt",
+                    b"Horse training transcript about saddle fit.",
+                    "text/plain",
+                )
+            },
+        )
+        assert upload.status_code == 200
+        document_id = upload.json()["id"]
+        run = client.post("/runs", json={"document_id": document_id})
+        assert run.status_code == 200
+        _wait_for_run(client, run.json()["id"])
+
+        bundle = client.get("/export/okf")
+        assert bundle.status_code == 200
+        payload = bundle.json()
+        assert payload["okf_version"] == "0.1"
+        assert "index.md" in payload["files"]
+        concept_paths = [p for p in payload["files"] if not p.endswith("index.md")]
+        assert concept_paths
+        frontmatter = yaml.safe_load(payload["files"][concept_paths[0]].split("---\n", 2)[1])
+        assert frontmatter["type"]
+        assert frontmatter["dewey_code"] == "636.1"
+
+        concept = client.get(f"/documents/{document_id}/okf")
+        assert concept.status_code == 200
+        assert concept.json()["path"].endswith(".md")
+        assert concept.json()["content"].startswith("---\n")
+
+    # A document that was never processed has no OKF concept.
+    with TestClient(create_app(settings)) as client:
+        missing = client.get("/documents/doc_missing/okf")
+        assert missing.status_code == 404

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -74,6 +74,38 @@ async def test_v3_classification_includes_title_and_tags() -> None:
 
 
 @pytest.mark.asyncio
+async def test_classification_includes_one_sentence_description() -> None:
+    classifier = _classifier(MockLLMProvider())
+
+    result = await classifier.execute(
+        DocumentId("doc_test"),
+        "A horse training transcript about a colt and groundwork.",
+    )
+
+    assert result.description == "A document about Horses & Equines."
+
+
+@pytest.mark.asyncio
+async def test_payload_without_description_leaves_it_unset() -> None:
+    classifier = _classifier(
+        _CannedProvider(
+            json.dumps(
+                {
+                    "summary": "A summary.",
+                    "dewey_code": "636.1",
+                    "category_name": "Horses & Equines",
+                    "confidence": 0.9,
+                }
+            )
+        )
+    )
+
+    result = await classifier.execute(DocumentId("doc_test"), "Saddle fit notes.")
+
+    assert result.description is None
+
+
+@pytest.mark.asyncio
 async def test_v2_style_payload_without_title_or_tags_still_parses() -> None:
     classifier = _classifier(
         _CannedProvider(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,6 +149,52 @@ def test_cli_json_drives_full_processing_loop(tmp_path: Path) -> None:
     assert detailed["results"][0]["classification_code"]
 
 
+def test_cli_export_okf_writes_conformant_bundle(tmp_path: Path) -> None:
+    import yaml
+
+    runner = CliRunner()
+    env = {
+        "LIBRARIAN_DATA_DIR": str(tmp_path / ".librarian"),
+        "LIBRARIAN_DATABASE_PATH": str(tmp_path / ".librarian" / "librarian.sqlite"),
+    }
+    source = tmp_path / "note.txt"
+    source.write_text(
+        "A horse training transcript about a colt and groundwork with saddle fit.",
+        encoding="utf-8",
+    )
+    document_id = json.loads(
+        _strip_ansi(runner.invoke(app, ["ingest", str(source), "--json"], env=env).output)
+    )["document_id"]
+    processed = runner.invoke(app, ["process", document_id, "--json"], env=env)
+    assert processed.exit_code == 0, processed.output
+
+    bundle = tmp_path / "bundle"
+    result = runner.invoke(app, ["export-okf", str(bundle), "--json"], env=env)
+    assert result.exit_code == 0, result.output
+    summary = json.loads(_strip_ansi(result.output))
+    assert summary["okf_version"] == "0.1"
+    assert summary["concepts"] == 1
+
+    assert (bundle / "index.md").exists()
+    concept_files = [p for p in bundle.rglob("*.md") if p.name != "index.md"]
+    assert concept_files
+    for path in concept_files:
+        text = path.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        frontmatter = yaml.safe_load(text.split("---\n", 2)[1])
+        assert frontmatter.get("type")
+
+
+def test_cli_export_okf_exits_nonzero_when_no_documents(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = {
+        "LIBRARIAN_DATA_DIR": str(tmp_path / ".librarian"),
+        "LIBRARIAN_DATABASE_PATH": str(tmp_path / ".librarian" / "librarian.sqlite"),
+    }
+    result = runner.invoke(app, ["export-okf", str(tmp_path / "bundle"), "--json"], env=env)
+    assert result.exit_code == 1
+
+
 def test_cli_doctor_strict_fails_when_optional_dependencies_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,7 +60,7 @@ def test_settings_default_prompt_stack() -> None:
     settings = Settings()
 
     assert settings.cleaning_prompt_version == "cmos_v2"
-    assert settings.classification_prompt_version == "dewey_v3"
+    assert settings.classification_prompt_version == "dewey_v4"
 
 
 def test_database_path_defaults_inside_data_dir() -> None:

--- a/tests/test_corpus_eval.py
+++ b/tests/test_corpus_eval.py
@@ -75,7 +75,7 @@ async def test_corpus_eval_runs_conversion_processing_and_search(tmp_path: Path)
     assert rendered["llm_provider"] == "mock"
     assert rendered["llm_model"] == "mock-cleaner"
     assert rendered["cleaning_prompt_version"] == "cmos_v2"
-    assert rendered["classification_prompt_version"] == "dewey_v3"
+    assert rendered["classification_prompt_version"] == "dewey_v4"
     assert rendered["generated_at"].endswith("+00:00")
     assert rendered["summary"]["case_count"] == 1
     assert rendered["summary"]["passed_count"] == 1

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -50,7 +50,7 @@ async def test_eval_suite_runs_against_configured_stack(tmp_path: Path) -> None:
     assert rendered["librarian_version"]
     assert rendered["generated_at"].endswith("+00:00")
     assert rendered["cleaning_prompt_version"] == "cmos_v2"
-    assert rendered["classification_prompt_version"] == "dewey_v3"
+    assert rendered["classification_prompt_version"] == "dewey_v4"
     assert rendered["summary"]["case_count"] == 1
     assert rendered["summary"]["passed_count"] == 1
     assert rendered["summary"]["failed_count"] == 0

--- a/tests/test_export_okf.py
+++ b/tests/test_export_okf.py
@@ -1,0 +1,247 @@
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import yaml
+
+from librarian.application.export_okf import OKF_VERSION, OkfSource, build_bundle
+from librarian.domain.ids import DocumentId, RunId
+from librarian.domain.models import Classification, CleanedOutput, Document, SourceFile
+from librarian.taxonomy.dewey import DeweyTaxonomy
+
+
+def _source(
+    *,
+    doc_id: str,
+    filename: str,
+    code: str,
+    label: str,
+    title: str | None,
+    tags: tuple[str, ...] = (),
+    description: str | None = None,
+    summary: str = "A synopsis. With two sentences.",
+    text: str = "Cleaned body text.",
+) -> OkfSource:
+    document = Document(
+        id=DocumentId(doc_id),
+        source=SourceFile(
+            path=Path("sources") / filename,
+            filename=filename,
+            media_type="application/octet-stream",
+            byte_size=100,
+            sha256="0" * 64,
+        ),
+    )
+    output = CleanedOutput(
+        document_id=DocumentId(doc_id),
+        run_id=RunId("run_test"),
+        text=text,
+        prompt_version="cmos_v2",
+        model_provider="mock",
+        model_name="mock-cleaner",
+        created_at=datetime(2026, 6, 13, 14, 30, 0, tzinfo=UTC),
+    )
+    classification = Classification(
+        document_id=DocumentId(doc_id),
+        code=code,
+        label=label,
+        summary=summary,
+        confidence=0.9,
+        title=title,
+        tags=tags,
+        description=description,
+    )
+    return OkfSource(document=document, output=output, classification=classification)
+
+
+def _split_frontmatter(content: str) -> tuple[dict[str, object], str]:
+    assert content.startswith("---\n")
+    _, frontmatter, body = content.split("---\n", 2)
+    parsed: object = yaml.safe_load(frontmatter)
+    assert isinstance(parsed, dict)
+    return cast(dict[str, object], parsed), body
+
+
+def test_bundle_is_okf_conformant() -> None:
+    files = build_bundle(
+        [
+            _source(
+                doc_id="doc_a",
+                filename="saddle.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title="Saddle Fit Notes",
+                tags=("horses", "saddle fit"),
+                description="A one-line abstract of the document.",
+            ),
+            _source(
+                doc_id="doc_b",
+                filename="catalog.docx",
+                code="020",
+                label="Library Science",
+                title="Catalog Design",
+            ),
+        ],
+        taxonomy=DeweyTaxonomy(),
+    )
+
+    # Conformance rule 1+2: every non-index .md has parseable frontmatter with a
+    # non-empty `type`.
+    concept_files = [p for p in files if not p.endswith("index.md")]
+    assert concept_files
+    for path in concept_files:
+        frontmatter, _ = _split_frontmatter(files[path])
+        assert isinstance(frontmatter.get("type"), str) and frontmatter["type"]
+
+    # Bundle-root index declares the OKF version (the only index frontmatter).
+    root_frontmatter, _ = _split_frontmatter(files["index.md"])
+    assert root_frontmatter["okf_version"] == OKF_VERSION
+
+
+def test_concept_path_uses_dewey_hierarchy_and_slug() -> None:
+    files = build_bundle(
+        [
+            _source(
+                doc_id="doc_a",
+                filename="saddle.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title="Saddle Fit & Groundwork Notes",
+            )
+        ],
+        taxonomy=DeweyTaxonomy(),
+    )
+    concept_path = next(p for p in files if not p.endswith("index.md"))
+    assert concept_path == (
+        "600-technology/630-agriculture/636-animal-husbandry/"
+        "636-1-horses-equines/saddle-fit-groundwork-notes.md"
+    )
+
+
+def test_frontmatter_maps_fields_and_escapes_safely() -> None:
+    files = build_bundle(
+        [
+            _source(
+                doc_id="doc_a",
+                filename="weird.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title='Tricky: "Quoted" Title',
+                tags=("a tag", "another"),
+                description="One sentence abstract.",
+            )
+        ],
+        taxonomy=DeweyTaxonomy(),
+    )
+    path = next(p for p in files if not p.endswith("index.md"))
+    frontmatter, body = _split_frontmatter(files[path])
+    assert frontmatter["type"] == "PDF Document"
+    assert frontmatter["title"] == 'Tricky: "Quoted" Title'
+    assert frontmatter["description"] == "One sentence abstract."
+    assert frontmatter["tags"] == ["a tag", "another"]
+    assert frontmatter["dewey_code"] == "636.1"
+    assert frontmatter["resource"] == "urn:librarian:doc:doc_a"
+    assert frontmatter["timestamp"] == "2026-06-13T14:30:00Z"
+    assert "Cleaned body text." in body
+
+
+def test_description_falls_back_to_first_sentence_of_summary() -> None:
+    files = build_bundle(
+        [
+            _source(
+                doc_id="doc_a",
+                filename="a.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title="Notes",
+                description=None,
+                summary="First sentence here. Second sentence is dropped.",
+            )
+        ],
+        taxonomy=DeweyTaxonomy(),
+    )
+    path = next(p for p in files if not p.endswith("index.md"))
+    frontmatter, _ = _split_frontmatter(files[path])
+    assert frontmatter["description"] == "First sentence here."
+
+
+def test_same_classification_concepts_cross_link() -> None:
+    files = build_bundle(
+        [
+            _source(
+                doc_id="doc_a",
+                filename="a.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title="First Horse Doc",
+            ),
+            _source(
+                doc_id="doc_b",
+                filename="b.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title="Second Horse Doc",
+            ),
+        ],
+        taxonomy=DeweyTaxonomy(),
+    )
+    first = files[
+        "600-technology/630-agriculture/636-animal-husbandry/636-1-horses-equines/first-horse-doc.md"
+    ]
+    assert "## Related" in first
+    assert "/636-1-horses-equines/second-horse-doc.md" in first
+
+
+def test_filename_collisions_are_numbered() -> None:
+    files = build_bundle(
+        [
+            _source(
+                doc_id="doc_a",
+                filename="a.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title="Same Title",
+            ),
+            _source(
+                doc_id="doc_b",
+                filename="b.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title="Same Title",
+            ),
+        ],
+        taxonomy=DeweyTaxonomy(),
+    )
+    concept_paths = {p for p in files if not p.endswith("index.md")}
+    assert any(p.endswith("/same-title.md") for p in concept_paths)
+    assert any(p.endswith("/same-title-2.md") for p in concept_paths)
+
+
+def test_indexes_cover_every_directory() -> None:
+    files = build_bundle(
+        [
+            _source(
+                doc_id="doc_a",
+                filename="a.pdf",
+                code="636.1",
+                label="Horses & Equines",
+                title="Horse Doc",
+            )
+        ],
+        taxonomy=DeweyTaxonomy(),
+    )
+    # An index.md exists at the root and at every directory level down to the leaf.
+    assert "index.md" in files
+    assert "600-technology/index.md" in files
+    assert (
+        "600-technology/630-agriculture/636-animal-husbandry/636-1-horses-equines/index.md" in files
+    )
+    root = files["index.md"]
+    assert "Technology" in root
+
+
+def test_empty_bundle_still_emits_conformant_root_index() -> None:
+    files = build_bundle([], taxonomy=DeweyTaxonomy())
+    assert list(files) == ["index.md"]
+    root_frontmatter, _ = _split_frontmatter(files["index.md"])
+    assert root_frontmatter["okf_version"] == OKF_VERSION

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -27,6 +27,16 @@ def test_prompt_catalog_loads_v3_classification_prompt() -> None:
     assert "confidence" in prompt
 
 
+def test_prompt_catalog_loads_v4_classification_prompt() -> None:
+    prompt = PromptCatalog().get("classification", "dewey_v4")
+
+    assert "Dewey Decimal Classification" in prompt
+    assert "single-sentence description" in prompt
+    assert '"description"' in prompt
+    assert '"title"' in prompt
+    assert '"tags"' in prompt
+
+
 def test_prompt_catalog_caches_prompt_reads() -> None:
     catalog = PromptCatalog()
     catalog.clear_cache()

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -87,7 +87,7 @@ async def test_real_provider_shipped_v2_eval_suite(tmp_path: Path) -> None:
     assert result.passed
     assert result.provider == "openai-compatible"
     assert result.cleaning_prompt_version == "cmos_v2"
-    assert result.classification_prompt_version == "dewey_v3"
+    assert result.classification_prompt_version == "dewey_v4"
 
 
 @pytest.mark.asyncio

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -74,7 +74,7 @@ def test_release_docs_describe_stable_surface() -> None:
     operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Version `1.4.0` is the stable production release." in readme
+    assert "Version `1.5.0` is the stable production release." in readme
     assert "librarian admin page-manifest" in operations
     assert "librarian maintainer eval" in operations
     assert "## 1.0.0 - 2026-05-22" in changelog

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -73,6 +73,7 @@ async def test_sqlite_initializes_schema(tmp_path: Path) -> None:
         "0004_raw_content_fts.sql",
         "0005_api_audit_events.sql",
         "0006_classification_title_tags.sql",
+        "0007_classification_description.sql",
     ]
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ wheels = [
 
 [[package]]
 name = "nampara-librarian"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -1046,7 +1046,9 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
     { name = "urllib3" },
 ]
 ocr = [
@@ -1099,10 +1101,12 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "python-docx", specifier = ">=1.1.2" },
     { name = "python-multipart", specifier = ">=0.0.12" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.9" },
     { name = "starlette", specifier = ">=1.0.1" },
     { name = "typer", specifier = ">=0.12.5" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "urllib3", marker = "extra == 'dev'", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6" },
 ]
@@ -2280,6 +2284,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Librarian can now emit a processed corpus as a conformant **Open Knowledge Format (OKF) v0.1** bundle — a vendor-neutral, agent- and human-readable directory of markdown concept files with YAML frontmatter ([spec](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)). Turn scanned PDFs, transcripts, and documents into a portable knowledge wiki an agent can reason over. Cut as **v1.5.0**.

There is **no runtime OKF dependency** (Google ships only a spec + a BigQuery-specific reference agent) — Librarian emits the format directly and pins `okf_version: "0.1"`.

### Engine
- **`export_okf.py`** builds a bundle: one concept file per processed document, organized into a **Dewey-derived directory hierarchy** (`600-technology/630-agriculture/636-animal-husbandry/636-1-horses-equines/…`), **cross-linked** to same-classification siblings (`## Related`), with generated **per-directory `index.md`** files and a root index declaring the OKF version. A strict internal YAML emitter (quoting/escaping) avoids a runtime dep.
- **Field mapping:** `type` = source document kind (`PDF Document`/`Transcript`/…); `title`/`description`/`tags`/`timestamp`/`resource` from classification; Dewey code/label/confidence as extension fields. `resource` is a portable `urn:librarian:doc:{id}` (no local-path leak).
- **One-sentence `description`:** new **`dewey_v4`** classification prompt produces a one-line abstract (stored via **migration `0007`**), used as the OKF `description`; documents classified before v4 fall back to the first sentence of their synopsis.

### Surfaces
- **CLI:** `librarian export-okf ./bundle [--classification-prefix 6] [--tag horses] [--limit N] [--json]` — idempotent, non-zero exit when nothing matches.
- **API:** `GET /export/okf` (whole bundle as a `{path: content}` file map) and `GET /documents/{id}/okf` (single concept).

### Conformance
A bundle is OKF v0.1 conformant if every non-reserved `.md` has parseable frontmatter with a non-empty `type`. The test suite **parses every emitted file with `pyyaml`** (dev-only dependency) and asserts it.

## Testing
- New `tests/test_export_okf.py` (8 tests): conformance, Dewey-hierarchy paths, frontmatter escaping (quotes/colons), description fallback, cross-links, collision numbering, index coverage, empty bundle.
- CLI end-to-end (`ingest → process → export-okf`, validates on-disk bundle) + non-zero-exit case; API endpoint test; `dewey_v4` prompt + `description` classification tests.
- Live-smoked the full pipeline (rendered bundle, concept frontmatter, root index verified by eye).
- `ruff` clean, `pyright` strict 0 errors, **511 passed / 3 skipped**, changelog ready for v1.5.0.
- Docs: new `docs/OKF.md` (field mapping, layout, conformance, versioning), README + `docs/API.md`.

A Mac-app **"Markdown (OKF bundle)"** output format is the planned fast follow.

🤖 Note: the `Info.plist` version bump triggers the Mac App build, which re-validates the OCR bundling on both arches.

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_