### PR TITLE
Relicense to MIT, Mac-app OKF output format, #### page headers (v1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 1.6.0 - 2026-06-14
+## 1.6.1 - 2026-06-14
 
-Relicensed to MIT, plus an OKF output mode in the Mac app and a small PDF cleanup.
+Relicensed to MIT, plus an OKF output mode in the Mac app and a small PDF cleanup. (The v1.6.0
+tag was accidentally created on the v1.5.0 commit before this work merged; protected tags cannot
+be moved, so it is retained as inert history and superseded by 1.6.1.)
 
 - **License changed from Apache-2.0 to the MIT License.** Librarian is now fully permissively
   open source; see [LICENSE](LICENSE).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.6.0 - 2026-06-14
+
+Relicensed to MIT, plus an OKF output mode in the Mac app and a small PDF cleanup.
+
+- **License changed from Apache-2.0 to the MIT License.** Librarian is now fully permissively
+  open source; see [LICENSE](LICENSE).
+- The Mac app gains a **"Markdown (OKF bundle)"** output format. Selecting it makes the
+  destination folder an Open Knowledge Format bundle: each finished document is folded into a
+  Dewey-organized tree of concept files (with a debounced whole-bundle rebuild so indexes and
+  cross-links stay consistent), instead of writing one file per document. The other formats
+  (Markdown / Plain Text / JSON) are unchanged. Built on the OKF producer shipped in 1.5.0.
+- PDF page section markers are now level-four headings (`#### Page N`) instead of `## Page N`, so
+  page boundaries no longer dominate a document's heading outline.
+
 ## 1.5.0 - 2026-06-14
 
 Librarian can now emit a processed corpus as an Open Knowledge Format (OKF) v0.1 bundle — a

--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,21 @@
+MIT License
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2026 Nampara AI
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-   1. Definitions.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Librarian is a local-first document ingestion, cleaning, classification, and search system. It converts transcripts, Markdown, text files, DOCX, PDFs, and OCR images into clean Markdown or plain text; processes them with an OpenAI-compatible model while preserving source fidelity; classifies the result with Dewey-style labels; and exposes the same engine through a Mac app, a CLI, and a FastAPI service.
 
-Version `1.5.0` is the stable production release. The default deployment is local or single-node: source documents and generated outputs stay in SQLite-backed local storage unless you configure an external model provider for cleaning, classification, or OCR correction.
+Version `1.6.0` is the stable production release. The default deployment is local or single-node: source documents and generated outputs stay in SQLite-backed local storage unless you configure an external model provider for cleaning, classification, or OCR correction.
 
 ## Mac App
 
@@ -34,7 +34,7 @@ From a downloaded release wheel:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install "nampara_librarian-1.5.0-py3-none-any.whl[all]"
+pip install "nampara_librarian-1.6.0-py3-none-any.whl[all]"
 ```
 
 From a source checkout:
@@ -171,4 +171,4 @@ vulnerability, follow [SECURITY.md](SECURITY.md). Release history is in [CHANGEL
 
 ## License
 
-Licensed under the Apache License 2.0 — see [LICENSE](LICENSE).
+Licensed under the MIT License — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Librarian is a local-first document ingestion, cleaning, classification, and search system. It converts transcripts, Markdown, text files, DOCX, PDFs, and OCR images into clean Markdown or plain text; processes them with an OpenAI-compatible model while preserving source fidelity; classifies the result with Dewey-style labels; and exposes the same engine through a Mac app, a CLI, and a FastAPI service.
 
-Version `1.6.0` is the stable production release. The default deployment is local or single-node: source documents and generated outputs stay in SQLite-backed local storage unless you configure an external model provider for cleaning, classification, or OCR correction.
+Version `1.6.1` is the stable production release. The default deployment is local or single-node: source documents and generated outputs stay in SQLite-backed local storage unless you configure an external model provider for cleaning, classification, or OCR correction.
 
 ## Mac App
 
@@ -34,7 +34,7 @@ From a downloaded release wheel:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install "nampara_librarian-1.6.0-py3-none-any.whl[all]"
+pip install "nampara_librarian-1.6.1-py3-none-any.whl[all]"
 ```
 
 From a source checkout:

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -17,7 +17,11 @@ to Applications, double-click, done.
   overwritten. Markdown output opens with a short synopsis, the
   classification, and topic tags above the cleaned text.
 - **Destination strip** at the top: Save to (any folder; default
-  `~/Documents/Librarian`) and Format (Markdown, Plain Text, JSON).
+  `~/Documents/Librarian`) and Format (Markdown, Plain Text, JSON, or
+  **Markdown (OKF bundle)**). In OKF-bundle mode the destination folder becomes
+  a single [Open Knowledge Format](../../docs/OKF.md) bundle — a Dewey-organized,
+  cross-linked, indexed tree of concept files — rebuilt as documents finish,
+  rather than one file per document.
 - **Settings (⌘, or the gear)**: one pane. Provider (Anthropic / OpenAI /
   OpenAI-compatible / Ollama / None), model, API key with inline validation.
   Keys are stored in the macOS Keychain — never on disk — and handed to the

--- a/apps/macos/Sources/Librarian/APIClient.swift
+++ b/apps/macos/Sources/Librarian/APIClient.swift
@@ -122,6 +122,13 @@ struct APIClient {
         return RawExport(data: data, suggestedStem: stem)
     }
 
+    /// The whole processed corpus rendered as an Open Knowledge Format bundle
+    /// (a map of bundle-relative path to markdown content).
+    func exportOkfBundle() async throws -> OkfBundle {
+        let (data, _) = try await send("GET", "/export/okf")
+        return try Self.decoder.decode(OkfBundle.self, from: data)
+    }
+
     func content(documentId: String, offset: Int = 0) async throws -> ContentPage {
         let (data, _) = try await send(
             "GET", "/documents/\(documentId)/content",

--- a/apps/macos/Sources/Librarian/AppModel.swift
+++ b/apps/macos/Sources/Librarian/AppModel.swift
@@ -26,6 +26,7 @@ final class AppModel: ObservableObject {
     private var documents: [Document] = []
     private var runs: [Run] = []
     private var exportsInFlight: Set<UUID> = []
+    private var okfSyncTask: Task<Void, Never>?
     private var pollTask: Task<Void, Never>?
     private var backendObservation: AnyCancellable?
 
@@ -341,6 +342,15 @@ final class AppModel: ObservableObject {
 
     private func startExport(itemID: UUID, documentID: String) {
         guard !exportsInFlight.contains(itemID) else { return }
+        // In OKF-bundle mode the destination folder *is* the bundle: the
+        // document is processed, so mark it saved and (debounced) rebuild the
+        // whole bundle from the engine. reconcileQueue skips terminal items, so
+        // this fires once per document.
+        if exportFormat.isBundle {
+            setStage(itemID, .done(outputURL: outputFolderURL))
+            scheduleOkfBundleSync()
+            return
+        }
         exportsInFlight.insert(itemID)
         let format = exportFormat
         let client = self.client
@@ -395,6 +405,55 @@ final class AppModel: ObservableObject {
                 )
             )
         }
+    }
+
+    /// Rebuild the OKF bundle into the destination folder after a short quiet
+    /// period, coalescing bursts of completions into a single write so the
+    /// bundle's indexes and cross-links stay consistent.
+    private func scheduleOkfBundleSync() {
+        okfSyncTask?.cancel()
+        let client = self.client
+        let folder = outputFolderURL
+        okfSyncTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1.5))
+            if Task.isCancelled { return }
+            guard let self else { return }
+            do {
+                let bundle = try await client.exportOkfBundle()
+                try await Self.writeOkfBundle(bundle, into: folder)
+            } catch {
+                // The documents are processed and will appear on the next
+                // successful sync (another completion or a manual refresh);
+                // leave the rows saved rather than failing them on a transient
+                // bundle-write error.
+                return
+            }
+        }
+    }
+
+    /// Write the bundle's path -> content map under `folder`, creating
+    /// subdirectories. Never deletes unmanaged files; guards against path
+    /// escapes even though the engine emits safe relative paths.
+    nonisolated static func writeOkfBundle(_ bundle: OkfBundle, into folder: URL) async throws {
+        try await Task.detached(priority: .utility) {
+            let manager = FileManager.default
+            try manager.createDirectory(at: folder, withIntermediateDirectories: true)
+            for (relativePath, content) in bundle.files {
+                let components = relativePath.split(separator: "/").map(String.init)
+                if components.isEmpty || components.contains("..") {
+                    continue
+                }
+                var destination = folder
+                for component in components {
+                    destination.appendPathComponent(component)
+                }
+                try manager.createDirectory(
+                    at: destination.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try Data(content.utf8).write(to: destination)
+            }
+        }.value
     }
 
     /// The engine sanitizes its suggested stem, but the filesystem is ours:

--- a/apps/macos/Sources/Librarian/Models.swift
+++ b/apps/macos/Sources/Librarian/Models.swift
@@ -115,6 +115,7 @@ enum ExportFormat: String, CaseIterable, Identifiable {
     case markdown = "md"
     case text = "txt"
     case json = "json"
+    case okfBundle = "okf"
 
     var id: String { rawValue }
 
@@ -123,10 +124,30 @@ enum ExportFormat: String, CaseIterable, Identifiable {
         case .markdown: return "Markdown"
         case .text: return "Plain Text"
         case .json: return "JSON"
+        case .okfBundle: return "Markdown (OKF bundle)"
         }
     }
 
-    var fileExtension: String { rawValue }
+    /// The per-document file extension. Unused for `.okfBundle`, which writes a
+    /// whole directory tree rather than one file per document.
+    var fileExtension: String {
+        switch self {
+        case .okfBundle: return "md"
+        default: return rawValue
+        }
+    }
+
+    /// Whether this format produces a single bundle directory instead of one
+    /// output file per document.
+    var isBundle: Bool { self == .okfBundle }
+}
+
+/// The Open Knowledge Format bundle returned by `GET /export/okf`: a map of
+/// bundle-relative path to file content, plus the declared OKF version.
+struct OkfBundle: Codable {
+    let okfVersion: String
+    let files: [String: String]
+    let skipped: [String]
 }
 
 /// One row in the main-window queue (redesign spec §5). The whole window

--- a/apps/macos/Sources/Librarian/Views/ContentView.swift
+++ b/apps/macos/Sources/Librarian/Views/ContentView.swift
@@ -86,6 +86,12 @@ struct DestinationStripView: View {
             }
             .labelsHidden()
             .fixedSize()
+            .help(
+                model.exportFormat.isBundle
+                    ? "Builds one navigable Open Knowledge Format bundle in the destination "
+                        + "folder instead of separate files."
+                    : "Choose how cleaned documents are written to the destination folder."
+            )
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)

--- a/apps/macos/Support/Info.plist
+++ b/apps/macos/Support/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleIconFile</key>

--- a/apps/macos/Support/Info.plist
+++ b/apps/macos/Support/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleIconFile</key>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ import root:
 docker run --rm -p 8080:8080 \
   -e LIBRARIAN_API_KEY=change-me \
   -e LIBRARIAN_API_IMPORT_ROOT=/data/imports \
-  ghcr.io/nampara-ai/librarian:v1.6.0
+  ghcr.io/nampara-ai/librarian:v1.6.1
 ```
 
 ## Environment

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ import root:
 docker run --rm -p 8080:8080 \
   -e LIBRARIAN_API_KEY=change-me \
   -e LIBRARIAN_API_IMPORT_ROOT=/data/imports \
-  ghcr.io/nampara-ai/librarian:v1.5.0
+  ghcr.io/nampara-ai/librarian:v1.6.0
 ```
 
 ## Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nampara-librarian"
-version = "1.5.0"
+version = "1.6.0"
 description = "Local-first corpus cleaner and library organizer with CLI and API surfaces."
 readme = "README.md"
 requires-python = ">=3.12"
-license = "Apache-2.0"
+license = "MIT"
 authors = [
   { name = "Nampara AI" }
 ]
@@ -19,7 +19,7 @@ classifiers = [
   "Framework :: FastAPI",
   "Intended Audience :: Developers",
   "Intended Audience :: End Users/Desktop",
-  "License :: OSI Approved :: Apache Software License",
+  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
   "Topic :: Text Processing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nampara-librarian"
-version = "1.6.0"
+version = "1.6.1"
 description = "Local-first corpus cleaner and library organizer with CLI and API surfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -1564,7 +1564,7 @@ def render_pdf_pages_markdown(path: Path, pages: Sequence[PdfPageExtraction]) ->
                     f"corrected: {str(page.corrected).lower()} -->"
                 ),
                 "",
-                f"## Page {page.page_number}",
+                f"#### Page {page.page_number}",
                 "",
                 page.text.strip(),
                 "",

--- a/src/librarian/version.py
+++ b/src/librarian/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/src/librarian/version.py
+++ b/src/librarian/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -361,7 +361,7 @@ async def test_pdf_ocr_passes_timeout_to_rasterizer(
 
     text = await PdfExtractor(ocr_timeout_seconds=9, ocr_correction_mode="never").extract(path)
 
-    assert "## Page 1" in text
+    assert "#### Page 1" in text
     assert "OCR text" in text
     assert "source: ocr" in text
     assert captured_kwargs["timeout"] == 9
@@ -411,11 +411,11 @@ async def test_pdf_extractor_ocr_handles_mixed_text_and_scanned_pages(
 
     text = await PdfExtractor(ocr_correction_mode="never").extract(path)
 
-    assert "## Page 1" in text
+    assert "#### Page 1" in text
     assert "Text page 1" in text
-    assert "## Page 2" in text
+    assert "#### Page 2" in text
     assert "OCR page 2" in text
-    assert "## Page 3" in text
+    assert "#### Page 3" in text
     assert "Text page 3" in text
 
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -74,7 +74,7 @@ def test_release_docs_describe_stable_surface() -> None:
     operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Version `1.5.0` is the stable production release." in readme
+    assert "Version `1.6.0` is the stable production release." in readme
     assert "librarian admin page-manifest" in operations
     assert "librarian maintainer eval" in operations
     assert "## 1.0.0 - 2026-05-22" in changelog

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -74,7 +74,7 @@ def test_release_docs_describe_stable_surface() -> None:
     operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Version `1.6.0` is the stable production release." in readme
+    assert "Version `1.6.1` is the stable production release." in readme
     assert "librarian admin page-manifest" in operations
     assert "librarian maintainer eval" in operations
     assert "## 1.0.0 - 2026-05-22" in changelog

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ wheels = [
 
 [[package]]
 name = "nampara-librarian"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ wheels = [
 
 [[package]]
 name = "nampara-librarian"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Three requested items in one cut (**v1.6.0**):

### 1. Relicense Apache-2.0 → MIT (fully open source)
- `LICENSE` replaced with the MIT License (© 2026 Nampara AI).
- `pyproject.toml`: `license = "MIT"` + `License :: OSI Approved :: MIT License` classifier.
- README License section updated.
- Verified the built wheel reports `License-Expression: MIT`, `License-File: LICENSE`, and the MIT classifier.

### 2. Mac app "Markdown (OKF bundle)" output format
- New `ExportFormat.okfBundle` ("Markdown (OKF bundle)") — the format picker iterates `allCases`, so it appears automatically.
- In OKF mode the **destination folder becomes the bundle**: each finished document marks done and triggers a **debounced (~1.5 s) whole-bundle resync** that fetches `GET /export/okf` (shipped in v1.5.0) and writes the `{path: content}` tree into the folder — subdirectories created, `..` path-escapes guarded, unmanaged user files never deleted. The other formats (Markdown/Plain Text/JSON) are untouched. `reconcileQueue` skips terminal items, so the resync fires once per document.
- Picker tooltip explains the mode.

### 3. PDF page markers `## Page N` → `#### Page N`
- One-line change in `render_pdf_pages_markdown` so page boundaries don't dominate a document's heading outline (also flows into OKF bundle bodies). Test assertions updated.

## Testing
- Engine gate green: `ruff` clean, `pyright` strict 0 errors, **511 passed / 3 skipped**, changelog ready for v1.6.0.
- `python -m build` succeeds with correct MIT metadata.
- Swift: brace/paren balance checked; the **Mac App PR build compiles all four touched Swift files and re-validates OCR bundling on both arches** (the gate for app code).
- Docs: CHANGELOG (license change called out), README, `apps/macos/README.md`.

🤖 The `apps/macos` changes trigger the Mac App build — that's the validation gate for the Swift OKF-export flow I can't compile locally.

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_