### PR TITLE
Add document series linking to connect recurring-source editions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+- Classification now captures a recurring-publication identity so editions of the same report are
+  connected over time: `issuer`, `series_title`, a normalized `series_key`, and an orderable
+  `period`. The new `dewey_v5` prompt extracts issuer/series/period; the `series_key` is derived
+  deterministically by stripping date/period tokens so monthly editions converge, and falls back to
+  a distinctive source filename when the model gives no series (generic names like `report.pdf` are
+  ignored). Documents classified before v5 keep parsing with these fields unset.
+- OKF export surfaces the series: each concept lists its other editions under a `## Series Editions`
+  heading ordered by reporting period, and carries `issuer` / `series` / `series_key` / `period` as
+  frontmatter extension fields. `librarian export-okf --series <key-or-name-fragment>` (and the
+  `series` query parameter on `GET /export/okf`) filters a bundle to one series.
+- New migration `0008_classification_series.sql` adds the four nullable columns and an index on
+  `series_key`.
+
 ## 1.6.1 - 2026-06-14
 
 Relicensed to MIT, plus an OKF output mode in the Mac app and a small PDF cleanup. (The v1.6.0

--- a/docs/OKF.md
+++ b/docs/OKF.md
@@ -18,6 +18,7 @@ CLI (for agents and bulk runs):
 librarian export-okf ./bundle              # all processed documents
 librarian export-okf ./bundle --classification-prefix 6   # only Dewey 6xx
 librarian export-okf ./bundle --tag horses --limit 50 --json
+librarian export-okf ./bundle --series cbre-marketview-dallas-office   # one recurring series
 ```
 
 `export-okf` includes only documents that have been processed (have a cleaned
@@ -26,7 +27,7 @@ command exits non-zero when no documents match.
 
 HTTP:
 
-- `GET /export/okf?classification_prefix=&tag=&limit=` → `{ "okf_version", "files": {path: content}, "skipped": [...] }`
+- `GET /export/okf?classification_prefix=&tag=&series=&limit=` → `{ "okf_version", "files": {path: content}, "skipped": [...] }`
 - `GET /documents/{id}/okf` → `{ "path", "content" }` for a single concept
 
 ## Bundle layout
@@ -51,6 +52,9 @@ index.md                                  # bundle root; declares okf_version
   (the `okf_version` declaration), as the spec requires.
 - Concepts that share a Dewey code are cross-linked under a `## Related`
   section, forming a graph richer than the directory tree.
+- Concepts that belong to the same recurring publication (same `series_key`) are
+  cross-linked under a `## Series Editions` section, ordered by reporting period,
+  so successive editions of one report thread together over time.
 
 ## Field mapping
 
@@ -68,6 +72,9 @@ document metadata:
 | `dewey_code` / `dewey_label` | classification | extension fields |
 | `source_filename` | original filename | extension field |
 | `classification_confidence` | classification confidence | extension field |
+| `issuer` | classification issuer | extension field; publishing org |
+| `series` / `series_key` | classification series title / normalized key | extension fields; recurring-publication identity |
+| `period` | classification reporting period | extension field; orderable token (`2026-05`, `2026-Q2`, `2026`) |
 
 The body is the cleaned markdown, preceded by the full synopsis as a blockquote.
 

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -1130,6 +1130,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def export_okf_bundle(
         classification_prefix: str | None = None,
         tag: str | None = None,
+        series: str | None = None,
         limit: Annotated[int | None, Query(ge=1, le=100_000)] = None,
     ) -> OkfBundleResponse:
         container = await build_ingest_container(settings)
@@ -1137,6 +1138,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             container.repository,
             classification_prefix=classification_prefix,
             tag=tag,
+            series=series,
             limit=limit,
         )
         files = build_bundle(sources, taxonomy=container.taxonomy)

--- a/src/librarian/application/classify_document.py
+++ b/src/librarian/application/classify_document.py
@@ -29,12 +29,164 @@ class ClassificationPayload(BaseModel):
     title: str | None = None
     tags: list[str] = []
     description: str | None = None
+    issuer: str | None = None
+    series: str | None = None
+    period: str | None = None
 
 
 _MAX_TAGS = 8
 _MAX_TAG_CHARS = 60
 _MAX_TITLE_CHARS = 120
 _MAX_DESCRIPTION_CHARS = 280
+_MAX_ISSUER_CHARS = 80
+_MAX_SERIES_TITLE_CHARS = 120
+_MAX_PERIOD_CHARS = 24
+_MAX_SERIES_KEY_CHARS = 80
+
+# ISO-style date stamps (``2026``, ``2026-06``, ``2026_06_15``, ``202606``,
+# ``2026-Q2``) stripped from a series identity first, so that filename-derived
+# keys like ``cbre-..._2026-06`` and ``cbre-..._2026-07`` collapse together. Digit
+# lookarounds are used instead of ``\b`` because ``_`` is a word character, so a
+# ``\b`` would not fire at the ``_2026`` boundary common in download filenames.
+_DATE_STAMP = re.compile(
+    r"(?<![0-9])(?:19|20)\d{2}"
+    r"(?:[-_./]?(?:q[1-4]|h[12]|0[1-9]|1[0-2]))?"
+    r"(?:[-_./]?(?:0[1-9]|[12]\d|3[01]))?"
+    r"(?![0-9])",
+    re.IGNORECASE,
+)
+
+# Named periods stripped from a series identity so that editions of one recurring
+# publication ("CBRE MarketView May 2026" vs "... June 2026") collapse to the same
+# ``series_key``. Month names (full or abbreviated), bare quarters, halves, and
+# fiscal years are removed. Month names are listed explicitly and word-bounded so
+# they match only whole tokens — "March" is stripped, "MarketView" is not.
+_PERIOD_TOKENS = re.compile(
+    r"\b(?:"
+    r"q[1-4]|h[12]|fy\s*\d{2,4}"
+    r"|jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?"
+    r"|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Month abbreviation -> two-digit number, used to canonicalize a reporting period
+# into an orderable ``YYYY-MM`` token when the model returns a month name.
+_MONTH_NUMBERS = {
+    "jan": "01",
+    "feb": "02",
+    "mar": "03",
+    "apr": "04",
+    "may": "05",
+    "jun": "06",
+    "jul": "07",
+    "aug": "08",
+    "sep": "09",
+    "sept": "09",
+    "oct": "10",
+    "nov": "11",
+    "dec": "12",
+}
+
+# Generic filename stems that must never seed a series identity on their own;
+# repeatedly downloading "report.pdf" should not merge unrelated documents.
+_GENERIC_SERIES_STEMS = frozenset(
+    {
+        "document",
+        "documents",
+        "report",
+        "reports",
+        "scan",
+        "scanned",
+        "file",
+        "files",
+        "download",
+        "downloads",
+        "untitled",
+        "copy",
+        "final",
+        "draft",
+        "new",
+    }
+)
+
+
+def _clean_one_line(value: str | None, *, max_chars: int) -> str | None:
+    if value is None:
+        return None
+    collapsed = " ".join(value.split())
+    return collapsed[:max_chars].strip() or None
+
+
+def _normalize_period(value: str | None) -> str | None:
+    """Canonicalize a reporting period into an orderable token.
+
+    Returns ``YYYY-MM`` / ``YYYY-Qn`` / ``YYYY-Hn`` / ``YYYY`` when the input is
+    recognizable, otherwise the cleaned free-text value. Lexicographic ordering
+    of these tokens matches chronological order within a series.
+    """
+    collapsed = _clean_one_line(value, max_chars=_MAX_PERIOD_CHARS)
+    if collapsed is None:
+        return None
+    iso = re.fullmatch(r"((?:19|20)\d{2})-(0[1-9]|1[0-2])", collapsed)
+    if iso:
+        return f"{iso.group(1)}-{iso.group(2)}"
+    lowered = collapsed.lower()
+    year_match = re.search(r"(?:19|20)\d{2}", lowered)
+    year = year_match.group(0) if year_match else None
+    if year is None:
+        return collapsed
+    quarter = re.search(r"q([1-4])", lowered)
+    if quarter:
+        return f"{year}-Q{quarter.group(1)}"
+    half = re.search(r"h([12])", lowered)
+    if half:
+        return f"{year}-H{half.group(1)}"
+    for name, number in _MONTH_NUMBERS.items():
+        if re.search(rf"\b{name}", lowered):
+            return f"{year}-{number}"
+    return year
+
+
+def _series_slug(raw: str) -> str:
+    without_dates = _DATE_STAMP.sub(" ", raw)
+    without_period = _PERIOD_TOKENS.sub(" ", without_dates)
+    slug = re.sub(r"[^a-z0-9]+", "-", without_period.lower()).strip("-")
+    return slug[:_MAX_SERIES_KEY_CHARS].strip("-")
+
+
+def _is_meaningful_series_slug(slug: str) -> bool:
+    tokens = [token for token in slug.split("-") if token]
+    if len(tokens) < 2 or len(slug) < 6:
+        return False
+    return not all(token in _GENERIC_SERIES_STEMS for token in tokens)
+
+
+def _series_key(
+    issuer: str | None,
+    series_title: str | None,
+    *,
+    fallback_filename: str | None,
+) -> str | None:
+    """Derive a stable identity for a recurring publication.
+
+    Built from issuer + series name when the model supplies them; otherwise
+    falls back to a period-stripped filename stem, but only when that stem is
+    distinctive enough to be a real series rather than a generic name.
+    """
+    primary = " ".join(part for part in (issuer, series_title) if part and part.strip())
+    if primary.strip():
+        return _series_slug(primary) or None
+    if fallback_filename:
+        stem = (
+            fallback_filename.rsplit(".", 1)[0]
+            if "." in fallback_filename
+            else fallback_filename
+        )
+        slug = _series_slug(stem)
+        if _is_meaningful_series_slug(slug):
+            return slug
+    return None
 
 
 def _clean_title(value: str | None) -> str | None:
@@ -78,7 +230,13 @@ class ClassifyDocument:
     temperature: float = 0.0
     max_response_chars: int = 2 * 1024 * 1024
 
-    async def execute(self, document_id: DocumentId, text: str) -> Classification:
+    async def execute(
+        self,
+        document_id: DocumentId,
+        text: str,
+        *,
+        source_filename: str | None = None,
+    ) -> Classification:
         prompt = self.prompt_catalog.get("classification", self.prompt_version)
         sample = text[:8_000]
         raw = await self.provider.complete(
@@ -103,6 +261,10 @@ class ClassifyDocument:
 
         code = payload.dewey_code.strip() or "000"
         label = payload.category_name.strip() or self.taxonomy.label_for(code) or "General"
+        issuer = _clean_one_line(payload.issuer, max_chars=_MAX_ISSUER_CHARS)
+        series_title = _clean_one_line(payload.series, max_chars=_MAX_SERIES_TITLE_CHARS)
+        period = _normalize_period(payload.period)
+        series_key = _series_key(issuer, series_title, fallback_filename=source_filename)
         return Classification(
             document_id=document_id,
             code=code,
@@ -113,6 +275,10 @@ class ClassifyDocument:
             title=_clean_title(payload.title),
             tags=_clean_tags(payload.tags),
             description=_clean_description(payload.description),
+            issuer=issuer,
+            series_key=series_key,
+            series_title=series_title,
+            period=period,
         )
 
 

--- a/src/librarian/application/export_okf.py
+++ b/src/librarian/application/export_okf.py
@@ -69,17 +69,21 @@ async def collect_sources(
     *,
     classification_prefix: str | None = None,
     tag: str | None = None,
+    series: str | None = None,
     limit: int | None = None,
 ) -> tuple[list[OkfSource], list[str]]:
     """Gather processed documents (with output + classification) for a bundle.
 
     Returns the included sources and the ids of documents skipped because they
     have not been processed (no cleaned output or classification yet). Documents
-    excluded by the prefix/tag filters are not counted as skipped.
+    excluded by the prefix/tag/series filters are not counted as skipped. The
+    ``series`` filter matches the stable ``series_key`` exactly or any substring
+    of the series key or display name, so a key or a name fragment both work.
     """
     sources: list[OkfSource] = []
     skipped: list[str] = []
     wanted_tag = tag.lower() if tag else None
+    wanted_series = series.lower() if series else None
     page = 200
     offset = 0
     while True:
@@ -96,6 +100,8 @@ async def collect_sources(
                 continue
             if wanted_tag and wanted_tag not in {t.lower() for t in classification.tags}:
                 continue
+            if wanted_series and not _series_matches(wanted_series, classification):
+                continue
             sources.append(
                 OkfSource(document=document, output=output, classification=classification)
             )
@@ -105,6 +111,14 @@ async def collect_sources(
             break
         offset += page
     return sources, skipped
+
+
+def _series_matches(wanted_series: str, classification: Classification) -> bool:
+    key = (classification.series_key or "").lower()
+    name = (classification.series_title or "").lower()
+    if wanted_series == key:
+        return True
+    return bool((key and wanted_series in key) or (name and wanted_series in name))
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +134,10 @@ class _Concept:
     dewey_label: str
     source_filename: str
     confidence: float | None
+    issuer: str | None
+    series_key: str | None
+    series_title: str | None
+    period: str | None
     summary: str
     body: str
 
@@ -128,6 +146,7 @@ def build_bundle(sources: list[OkfSource], *, taxonomy: TaxonomyProvider) -> dic
     """Render the sources into a map of bundle-relative path -> file content."""
     concepts: list[_Concept] = []
     by_code: dict[str, list[_Concept]] = defaultdict(list)
+    by_series: dict[str, list[_Concept]] = defaultdict(list)
     dir_labels: dict[str, str] = {}
     used_paths: set[str] = set()
 
@@ -136,6 +155,8 @@ def build_bundle(sources: list[OkfSource], *, taxonomy: TaxonomyProvider) -> dic
         used_paths.add(concept.path)
         concepts.append(concept)
         by_code[concept.code].append(concept)
+        if concept.series_key:
+            by_series[concept.series_key].append(concept)
 
     files: dict[str, str] = {}
     for concept in concepts:
@@ -144,10 +165,28 @@ def build_bundle(sources: list[OkfSource], *, taxonomy: TaxonomyProvider) -> dic
             for other in by_code[concept.code]
             if other.path != concept.path
         ][:_MAX_RELATED]
-        files[concept.path] = _render_concept(concept, related)
+        editions = _series_editions(concept, by_series)
+        files[concept.path] = _render_concept(concept, related, editions)
 
     files.update(_build_indexes(concepts, dir_labels))
     return files
+
+
+def _series_editions(
+    concept: _Concept,
+    by_series: dict[str, list[_Concept]],
+) -> list[tuple[str, str]]:
+    """Other editions of the same recurring series, ordered by reporting period."""
+    if not concept.series_key:
+        return []
+    siblings = [
+        other for other in by_series.get(concept.series_key, []) if other.path != concept.path
+    ]
+    siblings.sort(key=lambda other: (other.period or "", other.title.lower()))
+    return [
+        (other.period or other.series_title or other.title, "/" + other.path)
+        for other in siblings[:_MAX_RELATED]
+    ]
 
 
 def _build_concept(
@@ -192,12 +231,20 @@ def _build_concept(
         dewey_label=label,
         source_filename=source.document.source.filename,
         confidence=classification.confidence,
+        issuer=classification.issuer,
+        series_key=classification.series_key,
+        series_title=classification.series_title,
+        period=classification.period,
         summary=classification.summary,
         body=source.output.text,
     )
 
 
-def _render_concept(concept: _Concept, related: list[tuple[str, str]]) -> str:
+def _render_concept(
+    concept: _Concept,
+    related: list[tuple[str, str]],
+    editions: list[tuple[str, str]],
+) -> str:
     frontmatter = _frontmatter(
         [
             ("type", concept.type),
@@ -210,6 +257,10 @@ def _render_concept(concept: _Concept, related: list[tuple[str, str]]) -> str:
             ("dewey_label", concept.dewey_label),
             ("source_filename", concept.source_filename),
             ("classification_confidence", concept.confidence),
+            ("issuer", concept.issuer),
+            ("series", concept.series_title),
+            ("series_key", concept.series_key),
+            ("period", concept.period),
         ]
     )
     parts = [frontmatter, ""]
@@ -217,6 +268,9 @@ def _render_concept(concept: _Concept, related: list[tuple[str, str]]) -> str:
     if summary:
         parts.extend([f"> {summary}", ""])
     parts.append(concept.body.strip())
+    if editions:
+        parts.extend(["", "## Series Editions", ""])
+        parts.extend(f"- [{label}]({link})" for label, link in editions)
     if related:
         parts.extend(["", "## Related", ""])
         parts.extend(f"- [{title}]({link})" for title, link in related)

--- a/src/librarian/application/process_document.py
+++ b/src/librarian/application/process_document.py
@@ -230,7 +230,11 @@ class ProcessDocument:
                     status=RunStatus.RUNNING,
                     stage=RunStage.CLASSIFY,
                 )
-                classification = await self.classifier.execute(document_id, assembled)
+                classification = await self.classifier.execute(
+                    document_id,
+                    assembled,
+                    source_filename=document.source.filename,
+                )
             await self._raise_if_canceled(run_id)
             async with self._timed_stage(RunStage.INDEX, run_id, document_id):
                 await self.runs.update_status(

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -1457,6 +1457,10 @@ def export_okf(
         str | None,
         typer.Option(help="Only include documents carrying this tag."),
     ] = None,
+    series: Annotated[
+        str | None,
+        typer.Option(help="Only include documents in this series (series key or name fragment)."),
+    ] = None,
     limit: Annotated[
         int | None,
         typer.Option(help="Maximum number of documents to include.", min=1),
@@ -1474,6 +1478,7 @@ def export_okf(
             container.repository,
             classification_prefix=classification_prefix,
             tag=tag,
+            series=series,
             limit=limit,
         )
         files = build_bundle(sources, taxonomy=container.taxonomy)

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -16,7 +16,9 @@ LogFormatSetting = Literal["json", "text"]
 LogLevelSetting = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 LlmProviderSetting = Literal["mock", "openai-compatible"]
 CleaningPromptVersionSetting = Literal["cmos_v1", "cmos_v2"]
-ClassificationPromptVersionSetting = Literal["dewey_v1", "dewey_v2", "dewey_v3", "dewey_v4"]
+ClassificationPromptVersionSetting = Literal[
+    "dewey_v1", "dewey_v2", "dewey_v3", "dewey_v4", "dewey_v5"
+]
 CleaningModeSetting = Literal["standard"]
 
 
@@ -47,7 +49,7 @@ class Settings(BaseSettings):
     llm_max_response_chars: int = Field(default=2 * 1024 * 1024, gt=0)
 
     cleaning_prompt_version: CleaningPromptVersionSetting = Field(default="cmos_v2")
-    classification_prompt_version: ClassificationPromptVersionSetting = Field(default="dewey_v4")
+    classification_prompt_version: ClassificationPromptVersionSetting = Field(default="dewey_v5")
     cleaning_mode: CleaningModeSetting = Field(default="standard")
     coherence_mode: CoherenceModeSetting = Field(default="balanced")
 

--- a/src/librarian/domain/models.py
+++ b/src/librarian/domain/models.py
@@ -100,6 +100,10 @@ class Classification:
     title: str | None = None
     tags: tuple[str, ...] = ()
     description: str | None = None
+    issuer: str | None = None
+    series_key: str | None = None
+    series_title: str | None = None
+    period: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/librarian/prompts/classification/dewey_v5.md
+++ b/src/librarian/prompts/classification/dewey_v5.md
@@ -1,0 +1,70 @@
+Analyze the supplied text as a professional librarian.
+
+Return:
+1. A synopsis of 80 to 100 words describing what the content is about.
+2. A single-sentence description (25 words or fewer) summarizing the entire document — a concise
+   one-line abstract suitable for a catalog entry.
+3. The most appropriate Dewey Decimal Classification code.
+4. The matching category name.
+5. A short descriptive title for the document: 3 to 8 words in title case, specific to this
+   document's actual content, suitable for use as a filename. Use only letters, digits, spaces,
+   hyphens, ampersands, commas, and apostrophes.
+6. Between 3 and 7 topical tags: short lowercase phrases naming the document's subjects.
+7. A confidence score from 0.0 to 1.0.
+8. The issuer: the organization or author that published the document (e.g. "CBRE", "Federal
+   Reserve", "Acme Capital"), or null if there is no identifiable publisher.
+9. The series: the stable name of the recurring publication this document belongs to, EXCLUDING
+   any date or period — for example "CBRE MarketView — Dallas Office", not "CBRE MarketView Dallas
+   Office Q2 2026". Use null for a one-off document that is not part of a recurring series.
+10. The period: the reporting period this edition covers, as an ISO-style token — "2026-05" for a
+    month, "2026-Q2" for a quarter, "2026-H1" for a half, or "2026" for a year. Use null if the
+    document is not tied to a specific period.
+
+Respond with only valid JSON using this exact shape:
+
+{
+  "summary": "80-to-100-word synopsis",
+  "description": "one-sentence abstract of the whole document",
+  "dewey_code": "XXX.X",
+  "category_name": "Category Name",
+  "title": "Short Descriptive Title",
+  "tags": ["first tag", "second tag", "third tag"],
+  "confidence": 0.0,
+  "issuer": "Publisher Name",
+  "series": "Recurring Publication Name",
+  "period": "2026-05"
+}
+
+Choose the most specific code that fits the dominant subject matter. Prefer the text's actual topic
+over incidental examples, names, or metaphors. The title and description must describe this specific
+document, not just its category.
+
+The series name must be stable across editions: two monthly issues of the same report must produce
+the identical series value, with only the period differing. Never put a date, month, quarter, or
+year inside the series value — that belongs in the period field.
+
+Example: a June 2026 issue of CBRE's Dallas office market report yields
+`"issuer": "CBRE"`, `"series": "CBRE MarketView — Dallas Office"`, `"period": "2026-06"`. The
+following month's issue yields the same issuer and series with `"period": "2026-07"`.
+
+Common Dewey codes for reference:
+- 000 = Computer Science & Information
+- 100 = Philosophy & Psychology
+- 200 = Religion
+- 300 = Social Sciences
+- 320 = Political Science
+- 330 = Economics
+- 340 = Law
+- 370 = Education
+- 400 = Language
+- 500 = Science
+- 600 = Technology
+- 610 = Medicine & Health
+- 630 = Agriculture
+- 636 = Animal Husbandry
+- 636.1 = Horses & Equines
+- 636.7 = Dogs
+- 636.8 = Cats
+- 700 = Arts & Recreation
+- 800 = Literature
+- 900 = History & Geography

--- a/src/librarian/storage/migrations/0008_classification_series.sql
+++ b/src/librarian/storage/migrations/0008_classification_series.sql
@@ -1,0 +1,10 @@
+ALTER TABLE classifications ADD COLUMN issuer TEXT;
+
+ALTER TABLE classifications ADD COLUMN series_key TEXT;
+
+ALTER TABLE classifications ADD COLUMN series_title TEXT;
+
+ALTER TABLE classifications ADD COLUMN period TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_classifications_series_key
+  ON classifications (series_key);

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -2412,9 +2412,10 @@ def _cleaned_output_from_row(row: sqlite3.Row) -> CleanedOutput:
 
 _CLASSIFICATION_UPSERT_SQL = """
     INSERT INTO classifications (
-      document_id, code, label, summary, taxonomy, confidence, title, tags, description
+      document_id, code, label, summary, taxonomy, confidence, title, tags, description,
+      issuer, series_key, series_title, period
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(document_id) DO UPDATE SET
       code = excluded.code,
       label = excluded.label,
@@ -2423,13 +2424,31 @@ _CLASSIFICATION_UPSERT_SQL = """
       confidence = excluded.confidence,
       title = excluded.title,
       tags = excluded.tags,
-      description = excluded.description
+      description = excluded.description,
+      issuer = excluded.issuer,
+      series_key = excluded.series_key,
+      series_title = excluded.series_title,
+      period = excluded.period
 """
 
 
 def _classification_upsert_params(
     classification: Classification,
-) -> tuple[str, str, str, str, str, float | None, str | None, str, str | None]:
+) -> tuple[
+    str,
+    str,
+    str,
+    str,
+    str,
+    float | None,
+    str | None,
+    str,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+]:
     return (
         str(classification.document_id),
         classification.code,
@@ -2440,6 +2459,10 @@ def _classification_upsert_params(
         classification.title,
         json.dumps(list(classification.tags)),
         classification.description,
+        classification.issuer,
+        classification.series_key,
+        classification.series_title,
+        classification.period,
     )
 
 
@@ -2453,6 +2476,12 @@ def _classification_tags_from_column(value: object) -> tuple[str, ...]:
     if not isinstance(decoded, list):
         return ()
     return tuple(str(tag) for tag in cast(list[object], decoded))
+
+
+def _classification_optional_text(row: sqlite3.Row, column: str) -> str | None:
+    """Read an optional TEXT column that may be absent on pre-migration rows."""
+    value = row[column] if column in row.keys() else None
+    return str(value) if value is not None else None
 
 
 def _classification_from_row(row: sqlite3.Row) -> Classification:
@@ -2469,6 +2498,10 @@ def _classification_from_row(row: sqlite3.Row) -> Classification:
         title=str(title) if title is not None else None,
         tags=_classification_tags_from_column(row["tags"]),
         description=str(description) if description is not None else None,
+        issuer=_classification_optional_text(row, "issuer"),
+        series_key=_classification_optional_text(row, "series_key"),
+        series_title=_classification_optional_text(row, "series_title"),
+        period=_classification_optional_text(row, "period"),
     )
 
 

--- a/tests/test_api_processing.py
+++ b/tests/test_api_processing.py
@@ -1430,7 +1430,7 @@ def test_api_config_exposes_operational_controls(tmp_path: Path) -> None:
     assert payload["ocr_preserve_page_images"] is True
     assert payload["ocr_rotation_retry"] is True
     assert payload["cleaning_prompt_version"] == "cmos_v2"
-    assert payload["classification_prompt_version"] == "dewey_v4"
+    assert payload["classification_prompt_version"] == "dewey_v5"
     assert payload["universal_timeout_seconds"] == 77
     assert payload["llm_max_retries"] == settings.llm_max_retries
     assert payload["api_auth_keys_configured"] == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,7 +60,7 @@ def test_settings_default_prompt_stack() -> None:
     settings = Settings()
 
     assert settings.cleaning_prompt_version == "cmos_v2"
-    assert settings.classification_prompt_version == "dewey_v4"
+    assert settings.classification_prompt_version == "dewey_v5"
 
 
 def test_database_path_defaults_inside_data_dir() -> None:

--- a/tests/test_corpus_eval.py
+++ b/tests/test_corpus_eval.py
@@ -75,7 +75,7 @@ async def test_corpus_eval_runs_conversion_processing_and_search(tmp_path: Path)
     assert rendered["llm_provider"] == "mock"
     assert rendered["llm_model"] == "mock-cleaner"
     assert rendered["cleaning_prompt_version"] == "cmos_v2"
-    assert rendered["classification_prompt_version"] == "dewey_v4"
+    assert rendered["classification_prompt_version"] == "dewey_v5"
     assert rendered["generated_at"].endswith("+00:00")
     assert rendered["summary"]["case_count"] == 1
     assert rendered["summary"]["passed_count"] == 1

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -50,7 +50,7 @@ async def test_eval_suite_runs_against_configured_stack(tmp_path: Path) -> None:
     assert rendered["librarian_version"]
     assert rendered["generated_at"].endswith("+00:00")
     assert rendered["cleaning_prompt_version"] == "cmos_v2"
-    assert rendered["classification_prompt_version"] == "dewey_v4"
+    assert rendered["classification_prompt_version"] == "dewey_v5"
     assert rendered["summary"]["case_count"] == 1
     assert rendered["summary"]["passed_count"] == 1
     assert rendered["summary"]["failed_count"] == 0

--- a/tests/test_export_okf.py
+++ b/tests/test_export_okf.py
@@ -1,13 +1,42 @@
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
+import pytest
 import yaml
 
-from librarian.application.export_okf import OKF_VERSION, OkfSource, build_bundle
+from librarian.application.export_okf import (
+    OKF_VERSION,
+    OkfSource,
+    build_bundle,
+    collect_sources,
+)
 from librarian.domain.ids import DocumentId, RunId
 from librarian.domain.models import Classification, CleanedOutput, Document, SourceFile
 from librarian.taxonomy.dewey import DeweyTaxonomy
+
+
+class _StubRepository:
+    """In-memory OKF repository backed by a fixed list of sources."""
+
+    def __init__(self, sources: list[OkfSource]) -> None:
+        self._sources = sources
+
+    async def list(self, *, limit: int = 100, offset: int = 0) -> Sequence[Document]:
+        return [source.document for source in self._sources][offset : offset + limit]
+
+    async def get_cleaned_output(self, document_id: DocumentId) -> CleanedOutput | None:
+        return next(
+            (s.output for s in self._sources if s.document.id == document_id),
+            None,
+        )
+
+    async def get_classification(self, document_id: DocumentId) -> Classification | None:
+        return next(
+            (s.classification for s in self._sources if s.document.id == document_id),
+            None,
+        )
 
 
 def _source(
@@ -21,6 +50,10 @@ def _source(
     description: str | None = None,
     summary: str = "A synopsis. With two sentences.",
     text: str = "Cleaned body text.",
+    issuer: str | None = None,
+    series_key: str | None = None,
+    series_title: str | None = None,
+    period: str | None = None,
 ) -> OkfSource:
     document = Document(
         id=DocumentId(doc_id),
@@ -50,6 +83,10 @@ def _source(
         title=title,
         tags=tags,
         description=description,
+        issuer=issuer,
+        series_key=series_key,
+        series_title=series_title,
+        period=period,
     )
     return OkfSource(document=document, output=output, classification=classification)
 
@@ -245,3 +282,68 @@ def test_empty_bundle_still_emits_conformant_root_index() -> None:
     assert list(files) == ["index.md"]
     root_frontmatter, _ = _split_frontmatter(files["index.md"])
     assert root_frontmatter["okf_version"] == OKF_VERSION
+
+
+def test_series_editions_cross_link_in_period_order() -> None:
+    editions = [
+        _source(
+            doc_id=f"doc_{period}",
+            filename=f"{period}.pdf",
+            code="330",
+            label="Economics",
+            title=f"Dallas Office MarketView {period}",
+            issuer="CBRE",
+            series_key="cbre-marketview-dallas-office",
+            series_title="CBRE MarketView — Dallas Office",
+            period=period,
+        )
+        for period in ("2026-07", "2026-05", "2026-06")  # deliberately out of order
+    ]
+    files = build_bundle(editions, taxonomy=DeweyTaxonomy())
+
+    july_path = next(p for p in files if p.endswith("dallas-office-marketview-2026-07.md"))
+    july = files[july_path]
+    assert "## Series Editions" in july
+    # Sibling editions are listed by ascending period (May before June). Scope the
+    # check to the editions block so the frontmatter timestamp can't interfere.
+    editions_block = july.split("## Series Editions", 1)[1].split("## Related", 1)[0]
+    assert editions_block.index("2026-05") < editions_block.index("2026-06")
+
+    frontmatter, _ = _split_frontmatter(july)
+    assert frontmatter["issuer"] == "CBRE"
+    assert frontmatter["series"] == "CBRE MarketView — Dallas Office"
+    assert frontmatter["series_key"] == "cbre-marketview-dallas-office"
+    assert frontmatter["period"] == "2026-07"
+
+
+@pytest.mark.asyncio
+async def test_collect_sources_filters_by_series() -> None:
+    dallas = _source(
+        doc_id="doc_dallas",
+        filename="dallas.pdf",
+        code="330",
+        label="Economics",
+        title="Dallas Report",
+        series_key="cbre-marketview-dallas-office",
+        series_title="CBRE MarketView — Dallas Office",
+    )
+    austin = _source(
+        doc_id="doc_austin",
+        filename="austin.pdf",
+        code="330",
+        label="Economics",
+        title="Austin Report",
+        series_key="cbre-marketview-austin-office",
+        series_title="CBRE MarketView — Austin Office",
+    )
+    repository = _StubRepository([dallas, austin])
+
+    # Exact key and a name fragment both select only the Dallas series.
+    by_key, _ = await collect_sources(repository, series="cbre-marketview-dallas-office")
+    assert [s.document.id for s in by_key] == [DocumentId("doc_dallas")]
+
+    by_fragment, _ = await collect_sources(repository, series="dallas")
+    assert [s.document.id for s in by_fragment] == [DocumentId("doc_dallas")]
+
+    none_match, _ = await collect_sources(repository, series="austin")
+    assert [s.document.id for s in none_match] == [DocumentId("doc_austin")]

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -87,7 +87,7 @@ async def test_real_provider_shipped_v2_eval_suite(tmp_path: Path) -> None:
     assert result.passed
     assert result.provider == "openai-compatible"
     assert result.cleaning_prompt_version == "cmos_v2"
-    assert result.classification_prompt_version == "dewey_v4"
+    assert result.classification_prompt_version == "dewey_v5"
 
 
 @pytest.mark.asyncio

--- a/tests/test_series_linking.py
+++ b/tests/test_series_linking.py
@@ -1,0 +1,114 @@
+import json
+
+import pytest
+
+from librarian.application.classify_document import ClassifyDocument
+from librarian.domain.ids import DocumentId
+from librarian.prompts import PromptCatalog
+from librarian.taxonomy.dewey import DeweyTaxonomy
+
+
+class _CannedProvider:
+    """Returns one fixed completion regardless of prompt."""
+
+    name = "canned"
+
+    def __init__(self, response: str) -> None:
+        self._response = response
+
+    async def complete(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        del system_prompt, user_prompt, model, max_tokens, temperature
+        return self._response
+
+
+def _payload(**extra: object) -> str:
+    base: dict[str, object] = {
+        "summary": "A market report.",
+        "dewey_code": "330",
+        "category_name": "Economics",
+        "title": "Dallas Office MarketView",
+        "confidence": 0.9,
+    }
+    base.update(extra)
+    return json.dumps(base)
+
+
+async def _classify(response: str, *, filename: str | None = None):
+    classifier = ClassifyDocument(
+        provider=_CannedProvider(response),
+        prompt_catalog=PromptCatalog(),
+        prompt_version="dewey_v5",
+        model="mock-cleaner",
+        taxonomy=DeweyTaxonomy(),
+    )
+    return await classifier.execute(
+        DocumentId("doc_test"),
+        "Quarterly Dallas office absorption and vacancy.",
+        source_filename=filename,
+    )
+
+
+@pytest.mark.asyncio
+async def test_classifier_extracts_issuer_series_and_period() -> None:
+    result = await _classify(
+        _payload(issuer="CBRE", series="MarketView — Dallas Office", period="June 2026")
+    )
+    assert result.issuer == "CBRE"
+    assert result.series_title == "MarketView — Dallas Office"
+    assert result.period == "2026-06"
+    assert result.series_key == "cbre-marketview-dallas-office"
+
+
+@pytest.mark.asyncio
+async def test_period_is_canonicalized_to_orderable_tokens() -> None:
+    assert (await _classify(_payload(period="2026-05"))).period == "2026-05"
+    assert (await _classify(_payload(period="May 2026"))).period == "2026-05"
+    assert (await _classify(_payload(period="Q2 2026"))).period == "2026-Q2"
+    assert (await _classify(_payload(period="H1 2026"))).period == "2026-H1"
+    assert (await _classify(_payload(period="2026"))).period == "2026"
+    # Unrecognized free text is preserved rather than dropped.
+    assert (await _classify(_payload(period="interim"))).period == "interim"
+
+
+@pytest.mark.asyncio
+async def test_editions_converge_to_one_series_key() -> None:
+    # The same recurring report named slightly differently month to month (and with
+    # the date embedded) must still produce an identical series_key.
+    may = await _classify(_payload(issuer="CBRE", series="MarketView Dallas Office May 2026"))
+    june = await _classify(
+        _payload(issuer="CBRE", series="MarketView, Dallas — Office (June 2026)")
+    )
+    assert may.series_key == june.series_key == "cbre-marketview-dallas-office"
+
+
+@pytest.mark.asyncio
+async def test_filename_fallback_converges_across_months() -> None:
+    june = await _classify(_payload(), filename="CBRE_Dallas_Office_MarketView_2026-06.pdf")
+    july = await _classify(_payload(), filename="CBRE_Dallas_Office_MarketView_2026-07.pdf")
+    assert june.series_key == july.series_key == "cbre-dallas-office-marketview"
+    assert june.issuer is None
+    assert june.series_title is None
+
+
+@pytest.mark.asyncio
+async def test_generic_or_missing_filename_creates_no_series() -> None:
+    for filename in ("report.pdf", "scan_2026-06.pdf", "final-draft.pdf", None):
+        result = await _classify(_payload(), filename=filename)
+        assert result.series_key is None
+
+
+@pytest.mark.asyncio
+async def test_pre_v5_payload_leaves_series_fields_unset() -> None:
+    result = await _classify(_payload())
+    assert result.issuer is None
+    assert result.series_key is None
+    assert result.series_title is None
+    assert result.period is None

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -12,7 +12,14 @@ from librarian.application.factory import build_container
 from librarian.application.jobs import InProcessJobRunner, QueueStatus, QueueWorker, RunQueue
 from librarian.config import Settings
 from librarian.domain.ids import DocumentId, RunId
-from librarian.domain.models import Document, DocumentStatus, RunStage, RunStatus, SourceFile
+from librarian.domain.models import (
+    Classification,
+    Document,
+    DocumentStatus,
+    RunStage,
+    RunStatus,
+    SourceFile,
+)
 from librarian.observability import MetricsRecorder
 from librarian.storage.sqlite import (
     SQLiteDatabase,
@@ -74,10 +81,48 @@ async def test_sqlite_initializes_schema(tmp_path: Path) -> None:
         "0005_api_audit_events.sql",
         "0006_classification_title_tags.sql",
         "0007_classification_description.sql",
+        "0008_classification_series.sql",
     ]
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
     assert synchronous == 1
+
+
+@pytest.mark.asyncio
+async def test_sqlite_classification_round_trips_series_fields(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "librarian.sqlite")
+    await database.initialize()
+    repository = SQLiteRepository(database)
+    document = Document(
+        id=DocumentId("doc_series"),
+        source=SourceFile(
+            path=tmp_path / "cbre.pdf",
+            filename="cbre.pdf",
+            media_type="application/pdf",
+            byte_size=10,
+            sha256="series-sha",
+        ),
+    )
+    await repository.save_document(document)
+    classification = Classification(
+        document_id=document.id,
+        code="330",
+        label="Economics",
+        summary="Quarterly office market report.",
+        confidence=0.8,
+        title="CBRE Dallas Office MarketView",
+        tags=("office", "dallas"),
+        description="A Dallas office market update.",
+        issuer="CBRE",
+        series_key="cbre-marketview-dallas-office",
+        series_title="CBRE MarketView — Dallas Office",
+        period="2026-06",
+    )
+
+    await repository.save_classification(classification)
+    loaded = await repository.get_classification(document.id)
+
+    assert loaded == classification
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Connects editions of a recurring publication over time instead of leaving them as unrelated documents that merely share a Dewey bucket. Classification now captures a recurring-publication identity — `issuer`, `series_title`, a normalized `series_key`, and an orderable `period` — persisted via new migration `0008` (nullable columns + an index on `series_key`). Pre-v5 rows and responses keep parsing with the fields unset.
- New `dewey_v5` prompt extracts issuer/series/period (default classification prompt bumped to `dewey_v5`; `dewey_v1`–`v4` stay bundled). `series_key` is derived deterministically by stripping date/period tokens so editions of one report converge to the same key, and falls back to a distinctive source filename when the model gives no series — generic names like `report.pdf` are ignored so unrelated documents are not merged.
- OKF export surfaces the series: each concept lists its other editions under a `## Series Editions` heading ordered by reporting period, and carries `issuer` / `series` / `series_key` / `period` as frontmatter extension fields. New `librarian export-okf --series <key-or-name-fragment>` and the `series` query parameter on `GET /export/okf` filter a bundle to one series.

This follows the same hexagonal boundaries and the same pattern by which `title` / `tags` / `description` were added (migrations `0006`/`0007`): domain stays free of infra, the column add is a new migration, and OKF reads the fields defensively.

## Verification

- [x] `ruff check .`
- [x] `pyright`
- [x] `pytest` (520 passed, 3 skipped — the skips require a live LLM provider and `poppler`/`pdftoppm`, unrelated to this change)
- [x] `python -m build` (the new `dewey_v5.md` prompt and `0008_classification_series.sql` migration are confirmed present in the built wheel)
- [ ] Docker build if deployment/runtime dependencies changed — n/a (no dependency changes)

## Data Safety

- [x] No private documents, transcripts, secrets, provider logs, or sensitive eval outputs added.
- [x] New fixtures are synthetic, public-domain, or explicitly approved for open-source use.

## Notes

- `series_key` is derived, not authored, so it is regenerable by re-running classification. The filename fallback only seeds a key when the period-stripped stem is distinctive (≥2 tokens, not all generic), to avoid merging documents that merely share a generic download name.
- `period` is canonicalized to orderable tokens (`2026-05`, `2026-Q2`, `2026-H1`, `2026`) so lexical ordering matches chronological order within a series; unrecognized free text is preserved rather than dropped.
- Tests cover key convergence across reworded/dated editions, the filename fallback and its generic-name guard, period canonicalization, the storage round-trip, the OKF `## Series Editions` cross-link ordering, and the `--series` filter.