### PR TITLE
Add extraction cache + timeout ceiling (extractor-upgrade Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@
   selects `auto` (default; liteparse when installed, otherwise the built-in pdfplumber + Tesseract
   path), `liteparse`, or `legacy`; the built-in path remains a per-document fallback. See `NOTICE`
   for attribution.
+- Content-hash extraction cache: extracted Markdown is cached by source SHA-256 plus a signature of
+  the extraction configuration (engine + OCR options), so re-ingesting unchanged files — or the same
+  bytes across documents — skips the parser/OCR work. The cache is config-aware (changing the engine
+  or OCR settings re-extracts rather than serving stale text) and never caches failures (transient
+  errors retry). New migration `0009_extraction_cache.sql`; toggle with
+  `LIBRARIAN_EXTRACTION_CACHE_ENABLED` (default on). `admin db-stats` reports the `extraction_cache`
+  row count.
+- Extraction timeout ceiling: `LIBRARIAN_EXTRACTION_TIMEOUT_SECONDS` (default `0`, disabled) bounds a
+  single document's extraction so one pathological file cannot hang a batch, raising
+  `ExtractionTimeoutError` when exceeded.
 
 - Classification now captures a recurring-publication identity so editions of the same report are
   connected over time: `issuer`, `series_title`, a normalized `series_key`, and an orderable

--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ classification, and OKF pipeline. Set `LIBRARIAN_PDF_ENGINE` to `auto` (default 
 when installed, else built-in), `liteparse` (force), or `legacy` (always built-in). Point
 `LIBRARIAN_LITEPARSE_OCR_SERVER_URL` at a Surya/EasyOCR/PaddleOCR server for higher-accuracy OCR.
 
+### Extraction throughput
+
+Two controls keep bulk ingestion fast and bounded:
+
+- **Content-hash extraction cache** (on by default): extracted Markdown is cached by the source
+  file's SHA-256 plus a signature of the extraction configuration, so re-ingesting unchanged files —
+  or the same bytes across documents — skips the parser/OCR work. The cache is config-aware (changing
+  `LIBRARIAN_PDF_ENGINE` or OCR settings re-extracts instead of serving stale text) and never caches
+  failures, so a transient error (e.g. an unreachable OCR server) is retried on the next run. Disable
+  with `LIBRARIAN_EXTRACTION_CACHE_ENABLED=false`. `librarian admin db-stats` reports the
+  `extraction_cache` row count.
+- **Extraction timeout** (off by default): set `LIBRARIAN_EXTRACTION_TIMEOUT_SECONDS` to a positive
+  number to cap how long a single document may spend in extraction, so one pathological file cannot
+  hang a batch.
+
 ### OCR system dependencies (CLI/API only)
 
 OCR for scanned or image-based PDFs needs two **system** binaries that cannot be installed via

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -2458,6 +2458,7 @@ def _build_extractor(
         liteparse_image_mode=settings.liteparse_image_mode,
         universal_max_input_bytes=settings.universal_max_input_bytes,
         universal_timeout_seconds=settings.universal_timeout_seconds,
+        extraction_timeout_seconds=settings.extraction_timeout_seconds,
         metrics=metrics,
     )
 

--- a/src/librarian/application/factory.py
+++ b/src/librarian/application/factory.py
@@ -12,7 +12,7 @@ from librarian.application.ports import ApplicationMetrics, LLMProvider
 from librarian.application.process_document import ProcessDocument
 from librarian.application.search_library import SearchLibrary
 from librarian.config import Settings
-from librarian.ingest.extractors import CompositeExtractor
+from librarian.ingest.extractors import CachingExtractor, CompositeExtractor
 from librarian.llm import LazyLLMProvider, build_provider
 from librarian.observability import NoOpMetricsRecorder
 from librarian.pipeline.chunking import ChunkingPolicy
@@ -76,12 +76,20 @@ async def build_ingest_container(
         liteparse_image_mode=resolved_settings.liteparse_image_mode,
         universal_max_input_bytes=resolved_settings.universal_max_input_bytes,
         universal_timeout_seconds=resolved_settings.universal_timeout_seconds,
+        extraction_timeout_seconds=resolved_settings.extraction_timeout_seconds,
         metrics=metrics,
     )
+    ingest_extractor: CachingExtractor | CompositeExtractor = extractor
+    if resolved_settings.extraction_cache_enabled:
+        ingest_extractor = CachingExtractor(
+            extractor,
+            repository,
+            config_signature=extractor.config_signature,
+        )
     ingest = IngestDocument(
         documents=repository,
         content=repository,
-        extractor=extractor,
+        extractor=ingest_extractor,
         max_source_bytes=resolved_settings.max_source_bytes,
     )
     return IngestContainer(

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -2430,4 +2430,5 @@ def _build_extractor(settings: Settings) -> CompositeExtractor:
         liteparse_image_mode=settings.liteparse_image_mode,
         universal_max_input_bytes=settings.universal_max_input_bytes,
         universal_timeout_seconds=settings.universal_timeout_seconds,
+        extraction_timeout_seconds=settings.extraction_timeout_seconds,
     )

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -71,6 +71,13 @@ class Settings(BaseSettings):
     liteparse_ocr_server_url: str | None = Field(default=None)
     liteparse_dpi: int = Field(default=150, gt=0)
     liteparse_image_mode: LiteParseImageMode = Field(default="placeholder")
+    # Extraction throughput controls. The content-hash extraction cache stores
+    # extracted Markdown keyed by file digest + extraction-config signature, so
+    # re-ingesting unchanged files (or the same file across documents) skips the
+    # expensive parser/OCR work. The timeout bounds a single extraction so one
+    # pathological file cannot hang a batch (0 disables the ceiling).
+    extraction_cache_enabled: bool = Field(default=True)
+    extraction_timeout_seconds: int = Field(default=0, ge=0)
     ocr_language: str = Field(default="eng")
     ocr_timeout_seconds: int = Field(default=120, gt=0)
     ocr_pdf_dpi: int = Field(default=200, gt=0)

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -14,7 +14,7 @@ import subprocess
 import tempfile
 import time
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast
@@ -850,6 +850,116 @@ def _extractor_metadata(extractor: object) -> dict[str, object] | None:
     return None
 
 
+# Bump when extraction output for a given config could change materially, to
+# invalidate every cached entry without a data migration.
+_EXTRACTION_CACHE_VERSION = 1
+
+
+def extraction_config_signature(params: Mapping[str, object]) -> str:
+    """Stable signature for the extraction-affecting configuration.
+
+    Two extractor configurations that would produce different Markdown for the
+    same bytes must hash differently; identical configurations must hash the
+    same across processes. Used as part of the extraction cache key so changing
+    the engine or OCR options correctly invalidates cached output.
+    """
+    payload = json.dumps(
+        {"version": _EXTRACTION_CACHE_VERSION, **params},
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+class ExtractionTimeoutError(TimeoutError):
+    """Raised when a single extraction exceeds the configured time ceiling."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionCacheEntry:
+    """A cached extraction result keyed by content digest and config signature."""
+
+    content_sha256: str
+    config_signature: str
+    source_extension: str
+    text: str
+
+
+class ExtractionCacheStore(Protocol):
+    """Persistence port for the content-hash extraction cache."""
+
+    async def get_extraction(self, content_sha256: str, config_signature: str) -> str | None: ...
+
+    async def put_extraction(self, entry: ExtractionCacheEntry) -> None: ...
+
+
+class CachingExtractor:
+    """Wrap an extractor with a content-hash + config-signature cache.
+
+    On a cache hit the expensive parser/OCR work is skipped entirely. The cache
+    is config-aware (the signature folds in the extraction engine and options),
+    so changing the engine or OCR settings re-extracts rather than serving stale
+    Markdown. Extraction failures are not cached: a transient error (e.g. an OCR
+    server being unreachable) must be retried on the next run.
+    """
+
+    def __init__(
+        self,
+        inner: TextExtractorLike,
+        cache: ExtractionCacheStore,
+        *,
+        config_signature: str,
+    ) -> None:
+        self._inner = inner
+        self._cache = cache
+        self._config_signature = config_signature
+        self.supported_extensions = inner.supported_extensions
+        self.last_metadata: dict[str, object] | None = None
+        self.last_cache_hit: bool | None = None
+        self._manifest_path: Path | None = None
+
+    async def extract(self, path: Path) -> str:
+        # A page-manifest request (the convert sidecar flow) needs the real
+        # per-page extraction to run, so bypass the cache while one is active.
+        if self._manifest_path is not None:
+            return await self._extract_uncached(path)
+
+        content_sha256 = await asyncio.to_thread(_file_sha256, path)
+        cached = await self._cache.get_extraction(content_sha256, self._config_signature)
+        if cached is not None:
+            self.last_cache_hit = True
+            self.last_metadata = {
+                "artifact_type": "extraction-cache-hit",
+                "engine": "cache",
+                "content_sha256": content_sha256,
+            }
+            return cached
+
+        text = await self._extract_uncached(path)
+        await self._cache.put_extraction(
+            ExtractionCacheEntry(
+                content_sha256=content_sha256,
+                config_signature=self._config_signature,
+                source_extension=path.suffix.lower(),
+                text=text,
+            )
+        )
+        return text
+
+    async def _extract_uncached(self, path: Path) -> str:
+        text = await self._inner.extract(path)
+        self.last_cache_hit = False
+        self.last_metadata = _extractor_metadata(self._inner)
+        return text
+
+    def set_page_manifest_path(self, path: Path | None) -> None:
+        self._manifest_path = path
+        setter = getattr(self._inner, "set_page_manifest_path", None)
+        if callable(setter):
+            setter(path)
+
+
 class CompositeExtractor:
     """Route extraction by file extension."""
 
@@ -881,6 +991,7 @@ class CompositeExtractor:
         liteparse_image_mode: str = "placeholder",
         universal_max_input_bytes: int = 50 * 1024 * 1024,
         universal_timeout_seconds: int = 120,
+        extraction_timeout_seconds: int = 0,
         metrics: ExtractionMetrics | None = None,
     ) -> None:
         pdf_extractor = PdfExtractor(
@@ -947,6 +1058,33 @@ class CompositeExtractor:
                 )
         self.supported_extensions = frozenset(self._extractors)
         self.last_metadata: dict[str, object] | None = None
+        self._extraction_timeout_seconds = extraction_timeout_seconds
+        # Signature of the extraction-affecting configuration, used as part of
+        # the extraction cache key so engine/OCR changes invalidate cached text.
+        self.config_signature = extraction_config_signature(
+            {
+                "pdf_engine": pdf_engine,
+                "liteparse_active": self.liteparse_active,
+                "liteparse_ocr_server_url": liteparse_ocr_server_url,
+                "liteparse_dpi": liteparse_dpi,
+                "liteparse_image_mode": liteparse_image_mode,
+                "ocr_language": ocr_language,
+                "ocr_pdf_dpi": ocr_pdf_dpi,
+                "ocr_pdf_max_pages": ocr_pdf_max_pages,
+                "ocr_preprocess_mode": ocr_preprocess_mode,
+                "ocr_threshold": ocr_threshold,
+                "ocr_rotation_retry": ocr_rotation_retry,
+                "ocr_correction_mode": ocr_correction_mode,
+                "ocr_correction_model": ocr_correction_model,
+                "ocr_low_confidence_threshold": ocr_low_confidence_threshold,
+                "ocr_correction": ocr_correction_provider is not None,
+                "pdf_max_pages": pdf_max_pages,
+                "pdf_max_input_bytes": pdf_max_input_bytes,
+                "text_max_input_bytes": text_max_input_bytes,
+                "docx_max_input_bytes": docx_max_input_bytes,
+                "universal_max_input_bytes": universal_max_input_bytes,
+            }
+        )
 
     async def extract(self, path: Path) -> str:
         extension = path.suffix.lower()
@@ -955,10 +1093,22 @@ class CompositeExtractor:
         extractor = self._extractors.get(extension)
         if extractor is None:
             raise ValueError(f"Unsupported file extension: {extension}")
-        text = await extractor.extract(path)
+        text = await self._extract_with_timeout(extractor, path)
         metadata = getattr(extractor, "last_metadata", None)
         self.last_metadata = metadata if isinstance(metadata, dict) else None
         return text
+
+    async def _extract_with_timeout(self, extractor: TextExtractorLike, path: Path) -> str:
+        if self._extraction_timeout_seconds <= 0:
+            return await extractor.extract(path)
+        try:
+            return await asyncio.wait_for(
+                extractor.extract(path), timeout=self._extraction_timeout_seconds
+            )
+        except TimeoutError as exc:
+            raise ExtractionTimeoutError(
+                f"Extraction exceeded {self._extraction_timeout_seconds}s: {path.name}"
+            ) from exc
 
     def set_page_manifest_path(self, path: Path | None) -> None:
         """Forward page manifest paths to extractors that support them."""

--- a/src/librarian/storage/migrations/0009_extraction_cache.sql
+++ b/src/librarian/storage/migrations/0009_extraction_cache.sql
@@ -1,0 +1,15 @@
+-- Content-hash extraction cache.
+--
+-- Caches extracted Markdown keyed by the source file's SHA-256 digest plus a
+-- signature of the extraction configuration (engine + options that affect the
+-- output). Unlike the document-level dedup, this is config-aware: changing the
+-- PDF engine or OCR settings produces a new signature and re-extracts, and the
+-- cache is shared across documents that happen to have identical bytes.
+CREATE TABLE IF NOT EXISTS extraction_cache (
+  content_sha256 TEXT NOT NULL,
+  config_signature TEXT NOT NULL,
+  source_extension TEXT NOT NULL,
+  text TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (content_sha256, config_signature)
+);

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from importlib.resources import files
 from pathlib import Path
-from typing import LiteralString, cast
+from typing import TYPE_CHECKING, LiteralString, cast
 
 from librarian.application.clean_chunks import CleanedChunk
 from librarian.application.jobs import QueuedRun, QueueStatus
@@ -36,6 +36,9 @@ from librarian.domain.models import (
     TranscriptCitation,
     utc_now,
 )
+
+if TYPE_CHECKING:
+    from librarian.ingest.extractors import ExtractionCacheEntry
 
 _SQLITE_BUSY_TIMEOUT_MS = 5_000
 _MAX_SEARCH_QUERY_CHARS = 4_096
@@ -249,6 +252,10 @@ class SQLiteDatabase:
                 "api_audit_events": self._scalar_int(
                     connection,
                     "SELECT COUNT(*) FROM api_audit_events",
+                ),
+                "extraction_cache": self._scalar_int(
+                    connection,
+                    "SELECT COUNT(*) FROM extraction_cache",
                 ),
             }
             source_file_bytes = self._scalar_int(
@@ -502,6 +509,16 @@ class SQLiteRepository:
     async def get_text(self, key: str) -> str:
         """Read text content by key."""
         return await asyncio.to_thread(self._get_text_sync, key)
+
+    async def get_extraction(self, content_sha256: str, config_signature: str) -> str | None:
+        """Return cached extracted text for a content digest + config signature."""
+        return await asyncio.to_thread(
+            self._get_extraction_sync, content_sha256, config_signature
+        )
+
+    async def put_extraction(self, entry: ExtractionCacheEntry) -> None:
+        """Store extracted text in the content-hash extraction cache."""
+        await asyncio.to_thread(self._put_extraction_sync, entry)
 
     async def save_many(self, chunks: Sequence[Chunk]) -> None:
         """Save chunks."""
@@ -991,6 +1008,39 @@ class SQLiteRepository:
         if row is None:
             raise KeyError(key)
         return str(row["text"])
+
+    def _get_extraction_sync(self, content_sha256: str, config_signature: str) -> str | None:
+        with self.database.connect() as connection:
+            row = connection.execute(
+                """
+                SELECT text FROM extraction_cache
+                WHERE content_sha256 = ? AND config_signature = ?
+                """,
+                (content_sha256, config_signature),
+            ).fetchone()
+        return None if row is None else str(row["text"])
+
+    def _put_extraction_sync(self, entry: ExtractionCacheEntry) -> None:
+        with self.database.connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO extraction_cache (
+                  content_sha256, config_signature, source_extension, text, created_at
+                )
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(content_sha256, config_signature) DO UPDATE SET
+                  source_extension = excluded.source_extension,
+                  text = excluded.text,
+                  created_at = excluded.created_at
+                """,
+                (
+                    entry.content_sha256,
+                    entry.config_signature,
+                    entry.source_extension,
+                    entry.text,
+                    utc_now().isoformat(),
+                ),
+            )
 
     def _save_chunks_sync(self, chunks: Sequence[Chunk]) -> None:
         with self.database.connect() as connection:

--- a/tests/test_extraction_cache.py
+++ b/tests/test_extraction_cache.py
@@ -1,0 +1,245 @@
+"""Tests for the content-hash extraction cache and the extraction timeout."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from librarian.ingest.extractors import (
+    CachingExtractor,
+    CompositeExtractor,
+    ExtractionCacheEntry,
+    ExtractionTimeoutError,
+    extraction_config_signature,
+)
+from librarian.storage.sqlite import SQLiteDatabase, SQLiteRepository
+
+
+class _InMemoryCache:
+    """Minimal ExtractionCacheStore for unit tests."""
+
+    def __init__(self) -> None:
+        self.entries: dict[tuple[str, str], str] = {}
+
+    async def get_extraction(self, content_sha256: str, config_signature: str) -> str | None:
+        return self.entries.get((content_sha256, config_signature))
+
+    async def put_extraction(self, entry: ExtractionCacheEntry) -> None:
+        self.entries[(entry.content_sha256, entry.config_signature)] = entry.text
+
+
+class _CountingExtractor:
+    """Inner extractor that records how many times it ran."""
+
+    supported_extensions = frozenset({".txt"})
+
+    def __init__(self, text: str = "extracted") -> None:
+        self.text = text
+        self.calls = 0
+        self.last_metadata: dict[str, object] | None = {"engine": "counting"}
+
+    async def extract(self, path: Path) -> str:
+        del path
+        self.calls += 1
+        return self.text
+
+
+def _write(tmp_path: Path, name: str, payload: bytes) -> Path:
+    source = tmp_path / name
+    source.write_bytes(payload)
+    return source
+
+
+def test_caching_extractor_skips_inner_on_hit(tmp_path: Path) -> None:
+    source = _write(tmp_path, "doc.txt", b"hello world")
+    inner = _CountingExtractor()
+    cache = _InMemoryCache()
+    extractor = CachingExtractor(inner, cache, config_signature="sig-1")
+
+    first = asyncio.run(extractor.extract(source))
+    assert first == "extracted"
+    assert inner.calls == 1
+    assert extractor.last_cache_hit is False
+
+    second = asyncio.run(extractor.extract(source))
+    assert second == "extracted"
+    assert inner.calls == 1  # served from cache
+    assert extractor.last_cache_hit is True
+    assert extractor.last_metadata is not None
+    assert extractor.last_metadata["engine"] == "cache"
+
+
+def test_caching_extractor_separates_by_config_signature(tmp_path: Path) -> None:
+    source = _write(tmp_path, "doc.txt", b"hello world")
+    cache = _InMemoryCache()
+    inner_a = _CountingExtractor(text="engine-a")
+    inner_b = _CountingExtractor(text="engine-b")
+
+    a = CachingExtractor(inner_a, cache, config_signature="sig-a")
+    b = CachingExtractor(inner_b, cache, config_signature="sig-b")
+
+    assert asyncio.run(a.extract(source)) == "engine-a"
+    # A different signature must miss and re-extract, not serve A's text.
+    assert asyncio.run(b.extract(source)) == "engine-b"
+    assert inner_a.calls == 1
+    assert inner_b.calls == 1
+
+
+def test_caching_extractor_does_not_cache_failures(tmp_path: Path) -> None:
+    source = _write(tmp_path, "doc.txt", b"hello world")
+    cache = _InMemoryCache()
+
+    class _FlakyExtractor:
+        supported_extensions = frozenset({".txt"})
+
+        def __init__(self) -> None:
+            self.calls = 0
+            self.last_metadata: dict[str, object] | None = None
+
+        async def extract(self, path: Path) -> str:
+            del path
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("transient failure")
+            return "recovered"
+
+    inner = _FlakyExtractor()
+    extractor = CachingExtractor(inner, cache, config_signature="sig-1")
+
+    with pytest.raises(RuntimeError, match="transient failure"):
+        asyncio.run(extractor.extract(source))
+    assert cache.entries == {}  # negative result not stored
+
+    # The retry must re-run the extractor and then succeed.
+    assert asyncio.run(extractor.extract(source)) == "recovered"
+    assert inner.calls == 2
+
+
+def test_caching_extractor_bypasses_cache_when_manifest_active(tmp_path: Path) -> None:
+    source = _write(tmp_path, "doc.txt", b"hello world")
+    inner = _CountingExtractor()
+    cache = _InMemoryCache()
+    extractor = CachingExtractor(inner, cache, config_signature="sig-1")
+    extractor.set_page_manifest_path(tmp_path / "manifest.json")
+
+    asyncio.run(extractor.extract(source))
+    asyncio.run(extractor.extract(source))
+
+    assert inner.calls == 2  # cache bypassed while a manifest is requested
+    assert cache.entries == {}
+
+
+def test_extraction_config_signature_is_stable_and_sensitive() -> None:
+    base = {"pdf_engine": "auto", "ocr_language": "eng"}
+    assert extraction_config_signature(base) == extraction_config_signature(dict(base))
+    assert extraction_config_signature(base) != extraction_config_signature(
+        {"pdf_engine": "legacy", "ocr_language": "eng"}
+    )
+
+
+def test_composite_config_signature_tracks_engine_change() -> None:
+    auto = CompositeExtractor(pdf_engine="auto")
+    legacy = CompositeExtractor(pdf_engine="legacy")
+    assert auto.config_signature != legacy.config_signature
+
+
+def test_extraction_timeout_raises(tmp_path: Path) -> None:
+    source = _write(tmp_path, "doc.txt", b"hello world")
+    composite = CompositeExtractor(pdf_engine="legacy", extraction_timeout_seconds=1)
+
+    class _SlowExtractor:
+        supported_extensions = frozenset({".txt"})
+        last_metadata: dict[str, object] | None = None
+
+        async def extract(self, path: Path) -> str:
+            del path
+            await asyncio.sleep(5)
+            return "never"
+
+    composite._extractors[".txt"] = _SlowExtractor()  # type: ignore[assignment]
+
+    with pytest.raises(ExtractionTimeoutError):
+        asyncio.run(composite.extract(source))
+
+
+def test_extraction_timeout_disabled_passes_through(tmp_path: Path) -> None:
+    source = _write(tmp_path, "doc.txt", b"hello world")
+    composite = CompositeExtractor(pdf_engine="legacy", extraction_timeout_seconds=0)
+
+    class _FastExtractor:
+        supported_extensions = frozenset({".txt"})
+        last_metadata: dict[str, object] | None = None
+
+        async def extract(self, path: Path) -> str:
+            del path
+            return "fast"
+
+    composite._extractors[".txt"] = _FastExtractor()  # type: ignore[assignment]
+
+    assert asyncio.run(composite.extract(source)) == "fast"
+
+
+@pytest.mark.asyncio
+async def test_sqlite_extraction_cache_round_trip(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "librarian.sqlite")
+    await database.initialize()
+    repository = SQLiteRepository(database)
+
+    assert await repository.get_extraction("sha-1", "sig-1") is None
+
+    await repository.put_extraction(
+        ExtractionCacheEntry(
+            content_sha256="sha-1",
+            config_signature="sig-1",
+            source_extension=".pdf",
+            text="# Cached Markdown",
+        )
+    )
+    assert await repository.get_extraction("sha-1", "sig-1") == "# Cached Markdown"
+    # A different signature is a distinct cache slot.
+    assert await repository.get_extraction("sha-1", "sig-2") is None
+
+    # Upsert overwrites the stored text for the same key.
+    await repository.put_extraction(
+        ExtractionCacheEntry(
+            content_sha256="sha-1",
+            config_signature="sig-1",
+            source_extension=".pdf",
+            text="# Updated",
+        )
+    )
+    assert await repository.get_extraction("sha-1", "sig-1") == "# Updated"
+
+
+@pytest.mark.asyncio
+async def test_sqlite_stats_report_extraction_cache(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "librarian.sqlite")
+    await database.initialize()
+    repository = SQLiteRepository(database)
+    await repository.put_extraction(
+        ExtractionCacheEntry(
+            content_sha256="sha-1",
+            config_signature="sig-1",
+            source_extension=".pdf",
+            text="# Cached",
+        )
+    )
+
+    stats = await database.stats()
+    assert stats.table_counts["extraction_cache"] == 1
+
+
+@pytest.mark.asyncio
+async def test_caching_extractor_with_sqlite_repository(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "librarian.sqlite")
+    await database.initialize()
+    repository = SQLiteRepository(database)
+    source = _write(tmp_path, "doc.txt", b"hello world")
+    inner = _CountingExtractor(text="from-engine")
+    extractor = CachingExtractor(inner, repository, config_signature="sig-1")
+
+    assert await extractor.extract(source) == "from-engine"
+    assert await extractor.extract(source) == "from-engine"
+    assert inner.calls == 1  # second call served by the SQLite cache

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -82,6 +82,7 @@ async def test_sqlite_initializes_schema(tmp_path: Path) -> None:
         "0006_classification_title_tags.sql",
         "0007_classification_description.sql",
         "0008_classification_series.sql",
+        "0009_extraction_cache.sql",
     ]
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"


### PR DESCRIPTION
## Summary

Phase 2 of the **extractor-upgrade**: Firecrawl-inspired throughput and robustness at the layer *above* the extractor — reimplemented clean-room (no AGPL code copied; Firecrawl is AGPL-3, so only ideas/architecture transfer).

> **Stacked on [#37](https://github.com/nampara-ai/librarian/pull/37)** (Phase 1). This PR targets `extractor-upgrade-phase1` so the diff shows only Phase 2. Merge #37 first, then retarget this to `extractor-upgrade` (or merge in order).

## Content-hash extraction cache

Ingestion already dedups identical files at the document level, but that cache is **not** config-aware — switching `LIBRARIAN_PDF_ENGINE` would serve stale extracted text. This adds a proper extraction cache that fixes that and extends reuse across documents.

- **New `extraction_cache` table** (migration `0009`) keyed by source SHA-256 + a signature of the extraction-affecting configuration (engine + OCR options).
- **`CachingExtractor`** wraps the composite extractor: on a hit it skips the parser/OCR work entirely; misses extract and populate the cache.
- **Config-aware**: changing the PDF engine or OCR settings produces a new signature and re-extracts instead of serving stale Markdown — a correctness fix over the document-level dedup. A version constant invalidates all entries without a data migration if extraction logic changes.
- **Failures are never cached** — a transient error (e.g. an unreachable OCR server, the exact symptom seen earlier on a large mixed PDF) retries on the next run rather than poisoning the cache.
- Wraps **only the ingest extractor** (via the factory) and **bypasses itself while a page manifest is requested**, so the `convert` sidecar flow is unchanged.
- `SQLiteRepository.get_extraction`/`put_extraction`; `admin db-stats` reports the `extraction_cache` row count. Toggle with `LIBRARIAN_EXTRACTION_CACHE_ENABLED` (default on).

## Extraction timeout ceiling

- `LIBRARIAN_EXTRACTION_TIMEOUT_SECONDS` (default `0` = off) bounds a single document's extraction via `asyncio.wait_for`, raising `ExtractionTimeoutError` so one pathological file cannot hang a batch.

## Tests & quality

11 new tests: cache hit/miss, config-signature separation, failure non-caching, manifest bypass, the timeout (raise + disabled pass-through), and the SQLite round-trip + stats. Full suite **536 passed / 3 skipped**, ruff clean, pyright 0 errors. No new dependencies.

## Still to come

- **Phase 2b** — `ProcessPoolExecutor` batch path for CPU-bound parallel extraction across documents (the more invasive throughput piece, deferred to its own PR).
- **Phase 3** — vision-LLM pass for charts/figures (liteparse `screenshot()` + figure bboxes).
- **Phase 4** — Mac app bundles the liteparse wheel.

