### PR TITLE
Vision-LLM figure/chart enrichment (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Vision-LLM figure/chart enrichment (opt-in, `LIBRARIAN_FIGURE_VISION_ENABLED`). With the liteparse
+  engine active, each embedded figure image is sent to a vision-capable model that returns a
+  description and, for charts, a reconstructed Markdown data table; the result is injected next to the
+  figure's placeholder so otherwise-lost chart data becomes searchable, classifiable text. Bounded by
+  `LIBRARIAN_FIGURE_VISION_MAX_FIGURES`/`_MIN_BYTES`/`_MAX_BYTES`/`_MAX_CONCURRENCY`; uses
+  `LIBRARIAN_FIGURE_VISION_MODEL` (defaults to the cleaning model). Per-figure failures are swallowed
+  so one bad image never fails the document, and the vision settings fold into the extraction-cache
+  signature. Providers gained a `describe_image` capability (OpenAI-compatible vision content parts;
+  deterministic mock for tests/dry runs).
 - High-fidelity PDF/image extraction via the optional `liteparse` engine
   ([liteparse](https://github.com/run-llama/liteparse), Apache-2.0). When the `liteparse` extra is
   installed (included in `[all]`), PDFs and images are extracted to Markdown with reconstructed

--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ classification, and OKF pipeline. Set `LIBRARIAN_PDF_ENGINE` to `auto` (default 
 when installed, else built-in), `liteparse` (force), or `legacy` (always built-in). Point
 `LIBRARIAN_LITEPARSE_OCR_SERVER_URL` at a Surya/EasyOCR/PaddleOCR server for higher-accuracy OCR.
 
+### Figure & chart enrichment (vision)
+
+Charts and figures carry data that plain extraction loses — liteparse leaves them as image
+placeholders. With a vision-capable model you can recover that data as text. Set
+`LIBRARIAN_FIGURE_VISION_ENABLED=true` (and `LIBRARIAN_FIGURE_VISION_MODEL` if your cleaning model
+isn't vision-capable): when the liteparse engine is active, each embedded figure image is sent to the
+model, which returns a description and — for charts — a reconstructed Markdown data table. The result
+is injected next to the figure's placeholder, so the chart's numbers flow into the same cleaning,
+classification, search, and OKF pipeline as everything else.
+
+It's off by default because it needs a vision model and adds per-figure cost/latency. Tunables:
+`LIBRARIAN_FIGURE_VISION_MAX_FIGURES` (cap per document, default 20),
+`LIBRARIAN_FIGURE_VISION_MIN_BYTES` / `_MAX_BYTES` (skip icons / oversized images), and
+`LIBRARIAN_FIGURE_VISION_MAX_CONCURRENCY`. A figure the model can't read is left as its plain
+placeholder rather than failing the document. (Vector-drawn charts that liteparse doesn't emit as
+embedded raster images aren't covered yet.)
+
 ### Extraction throughput
 
 Two controls keep bulk ingestion fast and bounded:

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -2457,6 +2457,17 @@ def _build_extractor(
         liteparse_ocr_server_url=settings.liteparse_ocr_server_url,
         liteparse_dpi=settings.liteparse_dpi,
         liteparse_image_mode=settings.liteparse_image_mode,
+        figure_vision_provider=(
+            LazyLLMProvider(settings, metrics=metrics)
+            if settings.figure_vision_enabled
+            else None
+        ),
+        figure_vision_model=settings.figure_vision_model or settings.llm_model,
+        figure_vision_max_figures=settings.figure_vision_max_figures,
+        figure_vision_min_bytes=settings.figure_vision_min_bytes,
+        figure_vision_max_bytes=settings.figure_vision_max_bytes,
+        figure_vision_max_concurrency=settings.figure_vision_max_concurrency,
+        figure_vision_max_response_chars=settings.figure_vision_max_response_chars,
         universal_max_input_bytes=settings.universal_max_input_bytes,
         universal_timeout_seconds=settings.universal_timeout_seconds,
         extraction_timeout_seconds=settings.extraction_timeout_seconds,

--- a/src/librarian/application/factory.py
+++ b/src/librarian/application/factory.py
@@ -74,6 +74,19 @@ async def build_ingest_container(
         liteparse_ocr_server_url=resolved_settings.liteparse_ocr_server_url,
         liteparse_dpi=resolved_settings.liteparse_dpi,
         liteparse_image_mode=resolved_settings.liteparse_image_mode,
+        figure_vision_provider=(
+            LazyLLMProvider(resolved_settings, metrics=metrics)
+            if resolved_settings.figure_vision_enabled
+            else None
+        ),
+        figure_vision_model=(
+            resolved_settings.figure_vision_model or resolved_settings.llm_model
+        ),
+        figure_vision_max_figures=resolved_settings.figure_vision_max_figures,
+        figure_vision_min_bytes=resolved_settings.figure_vision_min_bytes,
+        figure_vision_max_bytes=resolved_settings.figure_vision_max_bytes,
+        figure_vision_max_concurrency=resolved_settings.figure_vision_max_concurrency,
+        figure_vision_max_response_chars=resolved_settings.figure_vision_max_response_chars,
         universal_max_input_bytes=resolved_settings.universal_max_input_bytes,
         universal_timeout_seconds=resolved_settings.universal_timeout_seconds,
         extraction_timeout_seconds=resolved_settings.extraction_timeout_seconds,

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -2429,6 +2429,15 @@ def _build_extractor(settings: Settings) -> CompositeExtractor:
         liteparse_ocr_server_url=settings.liteparse_ocr_server_url,
         liteparse_dpi=settings.liteparse_dpi,
         liteparse_image_mode=settings.liteparse_image_mode,
+        figure_vision_provider=(
+            LazyLLMProvider(settings) if settings.figure_vision_enabled else None
+        ),
+        figure_vision_model=settings.figure_vision_model or settings.llm_model,
+        figure_vision_max_figures=settings.figure_vision_max_figures,
+        figure_vision_min_bytes=settings.figure_vision_min_bytes,
+        figure_vision_max_bytes=settings.figure_vision_max_bytes,
+        figure_vision_max_concurrency=settings.figure_vision_max_concurrency,
+        figure_vision_max_response_chars=settings.figure_vision_max_response_chars,
         universal_max_input_bytes=settings.universal_max_input_bytes,
         universal_timeout_seconds=settings.universal_timeout_seconds,
         extraction_timeout_seconds=settings.extraction_timeout_seconds,

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -78,6 +78,19 @@ class Settings(BaseSettings):
     # pathological file cannot hang a batch (0 disables the ceiling).
     extraction_cache_enabled: bool = Field(default=True)
     extraction_timeout_seconds: int = Field(default=0, ge=0)
+    # Vision-LLM enrichment of embedded figures/charts. When enabled (and the
+    # liteparse engine is active), each embedded figure image is sent to a
+    # vision-capable model that returns a description and, for charts, a data
+    # table; the result is injected next to the figure's markdown placeholder so
+    # the otherwise-lost chart data becomes searchable text. Off by default
+    # because it requires a vision model and adds per-figure cost/latency.
+    figure_vision_enabled: bool = Field(default=False)
+    figure_vision_model: str | None = Field(default=None)
+    figure_vision_max_figures: int = Field(default=20, gt=0)
+    figure_vision_min_bytes: int = Field(default=2048, ge=0)
+    figure_vision_max_bytes: int = Field(default=8 * 1024 * 1024, gt=0)
+    figure_vision_max_concurrency: int = Field(default=2, gt=0)
+    figure_vision_max_response_chars: int = Field(default=16 * 1024, gt=0)
     # How many files a directory import converts/ingests concurrently. The
     # expensive extraction step runs in worker threads, so parallel files
     # overlap their parser/OCR work. For PROCESS/QUEUE imports this also overlaps

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import importlib
 import importlib.util
@@ -739,6 +740,125 @@ def liteparse_available() -> bool:
     return importlib.util.find_spec("liteparse") is not None
 
 
+FIGURE_VISION_SYSTEM_PROMPT = """You describe figures extracted from documents so their \
+information survives as text. Be faithful and specific; never invent data that is not visible."""
+
+FIGURE_VISION_USER_PROMPT = """Describe this figure from a document in Markdown.
+- State what the figure shows in one or two sentences.
+- If it is a chart or graph, reconstruct the underlying data as a Markdown table (axis labels,
+  series names, and the values you can read). Include units.
+- If it is a diagram, photo, or logo, describe it briefly instead of tabulating.
+Return only the description (and table if applicable). Do not add commentary about the task."""
+
+
+class FigureVisionProvider(Protocol):
+    """Minimal vision-capable LLM surface for figure enrichment."""
+
+    @property
+    def name(self) -> str: ...
+
+    async def describe_image(
+        self,
+        *,
+        image_base64: str,
+        media_type: str,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class FigureImage:
+    """One embedded figure image to enrich, keyed by its markdown placeholder id."""
+
+    id: str
+    page: int
+    media_type: str
+    data: bytes
+
+    @property
+    def placeholder(self) -> str:
+        """The markdown placeholder liteparse emits for this image."""
+        return f"![](image_{self.id}.png)"
+
+
+_FIGURE_MEDIA_TYPES = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+
+
+def figure_media_type(image_format: str) -> str:
+    """Map a liteparse image format to an IANA media type (default PNG)."""
+    return _FIGURE_MEDIA_TYPES.get(image_format.lower().lstrip("."), "image/png")
+
+
+async def enrich_markdown_figures(
+    markdown: str,
+    figures: Sequence[FigureImage],
+    *,
+    provider: FigureVisionProvider,
+    model: str,
+    max_figures: int,
+    min_bytes: int,
+    max_bytes: int,
+    max_concurrency: int,
+    max_response_chars: int,
+    temperature: float = 0.0,
+) -> tuple[str, int]:
+    """Inject vision-LLM descriptions next to figure placeholders in the markdown.
+
+    Only figures whose placeholder actually appears in the markdown and whose
+    size is within ``[min_bytes, max_bytes]`` are sent to the model, capped at
+    ``max_figures``. Per-figure failures are swallowed so one bad image never
+    fails the whole extraction. Returns the enriched markdown and the number of
+    figures successfully described.
+    """
+    eligible = [
+        figure
+        for figure in figures
+        if figure.placeholder in markdown and min_bytes <= len(figure.data) <= max_bytes
+    ][:max_figures]
+    if not eligible:
+        return markdown, 0
+
+    semaphore = asyncio.Semaphore(max(1, max_concurrency))
+
+    async def describe(figure: FigureImage) -> tuple[FigureImage, str | None]:
+        async with semaphore:
+            try:
+                description = await provider.describe_image(
+                    image_base64=base64.b64encode(figure.data).decode("ascii"),
+                    media_type=figure.media_type,
+                    system_prompt=FIGURE_VISION_SYSTEM_PROMPT,
+                    user_prompt=FIGURE_VISION_USER_PROMPT,
+                    model=model,
+                    max_tokens=2048,
+                    temperature=temperature,
+                )
+            except Exception:  # noqa: BLE001 - one figure must not fail the document
+                return figure, None
+        return figure, description.strip()[:max_response_chars] or None
+
+    described = await asyncio.gather(*(describe(figure) for figure in eligible))
+
+    enriched = markdown
+    count = 0
+    for figure, description in described:
+        if not description:
+            continue
+        block = f"{figure.placeholder}\n\n**Figure (page {figure.page}):** {description}"
+        enriched = enriched.replace(figure.placeholder, block, 1)
+        count += 1
+    return enriched, count
+
+
 class LiteParseExtractor:
     """Extract PDFs and images to rich Markdown via the liteparse engine.
 
@@ -760,6 +880,13 @@ class LiteParseExtractor:
         image_mode: str = "placeholder",
         max_pages: int | None = None,
         max_input_bytes: int = 200 * 1024 * 1024,
+        vision_provider: FigureVisionProvider | None = None,
+        vision_model: str = "mock-cleaner",
+        vision_max_figures: int = 20,
+        vision_min_bytes: int = 2048,
+        vision_max_bytes: int = 8 * 1024 * 1024,
+        vision_max_concurrency: int = 2,
+        vision_max_response_chars: int = 16 * 1024,
     ) -> None:
         self.ocr_language = ocr_language
         self.ocr_server_url = ocr_server_url
@@ -767,37 +894,77 @@ class LiteParseExtractor:
         self.image_mode = image_mode
         self.max_pages = max_pages
         self.max_input_bytes = max_input_bytes
+        self.vision_provider = vision_provider
+        self.vision_model = vision_model
+        self.vision_max_figures = vision_max_figures
+        self.vision_min_bytes = vision_min_bytes
+        self.vision_max_bytes = vision_max_bytes
+        self.vision_max_concurrency = vision_max_concurrency
+        self.vision_max_response_chars = vision_max_response_chars
         self.last_metadata: dict[str, object] | None = None
+
+    @property
+    def vision_active(self) -> bool:
+        return self.vision_provider is not None
 
     async def extract(self, path: Path) -> str:
         _validate_input_size(path, self.max_input_bytes, "LiteParse extraction input")
-        text = await asyncio.to_thread(self._extract_sync, path)
+        text, figures = await asyncio.to_thread(self._extract_sync, path)
         if not text.strip():
             raise ValueError(f"No extractable content found: {path}")
-        self.last_metadata = {
+        metadata: dict[str, object] = {
             "artifact_type": "liteparse-extraction",
             "engine": "liteparse",
             "source_file": path.name,
         }
+        if self.vision_provider is not None and figures:
+            text, described = await enrich_markdown_figures(
+                text,
+                figures,
+                provider=self.vision_provider,
+                model=self.vision_model,
+                max_figures=self.vision_max_figures,
+                min_bytes=self.vision_min_bytes,
+                max_bytes=self.vision_max_bytes,
+                max_concurrency=self.vision_max_concurrency,
+                max_response_chars=self.vision_max_response_chars,
+            )
+            if described:
+                metadata["figures_described"] = described
+        self.last_metadata = metadata
         return text
 
-    def _extract_sync(self, path: Path) -> str:
+    def _extract_sync(self, path: Path) -> tuple[str, list[FigureImage]]:
         try:
             liteparse = importlib.import_module("liteparse")
         except ImportError as exc:  # pragma: no cover - guarded by liteparse_available
             raise RuntimeError("PDF/image extraction requires the 'liteparse' extra") from exc
+        # Vision enrichment needs the raw image bytes, which liteparse only
+        # populates in "embed" mode; the markdown placeholders are identical.
+        image_mode = "embed" if self.vision_provider is not None else self.image_mode
         parser = liteparse.LiteParse(
             output_format="markdown",
             ocr_enabled=True,
             ocr_server_url=self.ocr_server_url,
             ocr_language=self.ocr_language,
-            image_mode=self.image_mode,
+            image_mode=image_mode,
             dpi=self.dpi,
             max_pages=self.max_pages,
             quiet=True,
         )
         result = parser.parse(str(path))
-        return cast(str, result.text)
+        figures: list[FigureImage] = []
+        if self.vision_provider is not None:
+            for image in result.images:
+                figures.append(
+                    FigureImage(
+                        id=str(image.id),
+                        page=int(image.page),
+                        media_type=figure_media_type(str(image.format)),
+                        data=bytes(image.bytes),
+                    )
+                )
+        return cast(str, result.text), figures
 
 
 class FallbackExtractor:
@@ -989,6 +1156,13 @@ class CompositeExtractor:
         liteparse_ocr_server_url: str | None = None,
         liteparse_dpi: int = 150,
         liteparse_image_mode: str = "placeholder",
+        figure_vision_provider: FigureVisionProvider | None = None,
+        figure_vision_model: str = "mock-cleaner",
+        figure_vision_max_figures: int = 20,
+        figure_vision_min_bytes: int = 2048,
+        figure_vision_max_bytes: int = 8 * 1024 * 1024,
+        figure_vision_max_concurrency: int = 2,
+        figure_vision_max_response_chars: int = 16 * 1024,
         universal_max_input_bytes: int = 50 * 1024 * 1024,
         universal_timeout_seconds: int = 120,
         extraction_timeout_seconds: int = 0,
@@ -1040,6 +1214,9 @@ class CompositeExtractor:
         # images through it for richer Markdown (tables/headings/figures,
         # selective OCR), keeping the built-in extractors as a fallback.
         self.liteparse_active = pdf_engine != "legacy" and liteparse_available()
+        # Vision enrichment only applies to the liteparse engine (it needs the
+        # engine's embedded figure images); it is off unless a provider is given.
+        self.figure_vision_active = self.liteparse_active and figure_vision_provider is not None
         if self.liteparse_active:
             liteparse_extractor = LiteParseExtractor(
                 ocr_language=ocr_language,
@@ -1048,6 +1225,13 @@ class CompositeExtractor:
                 image_mode=liteparse_image_mode,
                 max_pages=pdf_max_pages,
                 max_input_bytes=pdf_max_input_bytes,
+                vision_provider=figure_vision_provider,
+                vision_model=figure_vision_model,
+                vision_max_figures=figure_vision_max_figures,
+                vision_min_bytes=figure_vision_min_bytes,
+                vision_max_bytes=figure_vision_max_bytes,
+                vision_max_concurrency=figure_vision_max_concurrency,
+                vision_max_response_chars=figure_vision_max_response_chars,
             )
             self._extractors[".pdf"] = FallbackExtractor(
                 liteparse_extractor, pdf_extractor, supported_extensions=frozenset({".pdf"})
@@ -1068,6 +1252,11 @@ class CompositeExtractor:
                 "liteparse_ocr_server_url": liteparse_ocr_server_url,
                 "liteparse_dpi": liteparse_dpi,
                 "liteparse_image_mode": liteparse_image_mode,
+                "figure_vision": self.figure_vision_active,
+                "figure_vision_model": figure_vision_model if self.figure_vision_active else None,
+                "figure_vision_max_figures": (
+                    figure_vision_max_figures if self.figure_vision_active else None
+                ),
                 "ocr_language": ocr_language,
                 "ocr_pdf_dpi": ocr_pdf_dpi,
                 "ocr_pdf_max_pages": ocr_pdf_max_pages,

--- a/src/librarian/llm/lazy.py
+++ b/src/librarian/llm/lazy.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from typing import cast
 
 from librarian.application.ports import ApplicationMetrics, LLMProvider
 from librarian.config import Settings
@@ -33,6 +35,32 @@ class LazyLLMProvider:
     ) -> str:
         provider = self._get_provider()
         return await provider.complete(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+    async def describe_image(
+        self,
+        *,
+        image_base64: str,
+        media_type: str,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        provider = self._get_provider()
+        describe = getattr(provider, "describe_image", None)
+        if not callable(describe):
+            raise RuntimeError(f"LLM provider {provider.name!r} does not support vision input")
+        describe = cast("Callable[..., Awaitable[str]]", describe)
+        return await describe(
+            image_base64=image_base64,
+            media_type=media_type,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             model=model,
@@ -73,6 +101,37 @@ class PromptSizeGuardProvider:
                 f"({prompt_chars} > {self.max_prompt_chars})"
             )
         return await self.provider.complete(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+    async def describe_image(
+        self,
+        *,
+        image_base64: str,
+        media_type: str,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        prompt_chars = len(system_prompt) + len(user_prompt)
+        if prompt_chars > self.max_prompt_chars:
+            raise ValueError(
+                "LLM prompt exceeded configured character limit "
+                f"({prompt_chars} > {self.max_prompt_chars})"
+            )
+        describe = getattr(self.provider, "describe_image", None)
+        if not callable(describe):
+            raise RuntimeError(f"LLM provider {self.provider.name!r} does not support vision input")
+        describe = cast("Callable[..., Awaitable[str]]", describe)
+        return await describe(
+            image_base64=image_base64,
+            media_type=media_type,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             model=model,

--- a/src/librarian/llm/mock.py
+++ b/src/librarian/llm/mock.py
@@ -53,6 +53,22 @@ class MockLLMProvider:
             )
         return _normalize_cleaned_text(user_prompt)
 
+    async def describe_image(
+        self,
+        *,
+        image_base64: str,
+        media_type: str,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        del system_prompt, user_prompt, model, max_tokens, temperature
+        # Deterministic, no-network stand-in: report the image size so tests and
+        # dry runs get stable, inspectable output without a vision model.
+        return f"Figure ({media_type}, {len(image_base64)} b64 chars): mock description."
+
 
 def _normalize_cleaned_text(value: str) -> str:
     """Normalize intra-line whitespace while preserving document structure."""

--- a/src/librarian/llm/openai_compatible.py
+++ b/src/librarian/llm/openai_compatible.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import random
-from typing import Protocol
+from typing import Any, Protocol, cast
 
 from openai import (
     APIConnectionError,
@@ -76,10 +76,13 @@ class OpenAICompatibleProvider:
         max_tokens: int,
         temperature: float,
     ) -> str:
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
         async with self._semaphore:
-            response = await self._complete_with_retries(
-                system_prompt=system_prompt,
-                user_prompt=user_prompt,
+            response = await self._chat_with_retries(
+                messages=messages,
                 model=model,
                 max_tokens=max_tokens,
                 temperature=temperature,
@@ -87,11 +90,44 @@ class OpenAICompatibleProvider:
         self._record_usage(response, model=model)
         return response.choices[0].message.content or ""
 
-    async def _complete_with_retries(
+    async def describe_image(
         self,
         *,
+        image_base64: str,
+        media_type: str,
         system_prompt: str,
         user_prompt: str,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": user_prompt},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{media_type};base64,{image_base64}"},
+                    },
+                ],
+            },
+        ]
+        async with self._semaphore:
+            response = await self._chat_with_retries(
+                messages=messages,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        self._record_usage(response, model=model)
+        return response.choices[0].message.content or ""
+
+    async def _chat_with_retries(
+        self,
+        *,
+        messages: list[Any],
         model: str,
         max_tokens: int,
         temperature: float,
@@ -103,10 +139,7 @@ class OpenAICompatibleProvider:
                     model=model,
                     max_tokens=max_tokens,
                     temperature=temperature,
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt},
-                    ],
+                    messages=cast("Any", messages),
                 )
             except Exception as exc:  # noqa: BLE001 - provider errors feed retry policy
                 if not is_retriable_openai_error(exc):

--- a/tests/test_figure_vision.py
+++ b/tests/test_figure_vision.py
@@ -110,7 +110,7 @@ def test_enrich_skips_placeholders_absent_from_markdown() -> None:
     figures = [_fig("present", 1, 5000), _fig("absent", 1, 5000)]
 
     provider = _FakeVision()
-    out, count = _enrich(md, figures, provider)
+    _out, count = _enrich(md, figures, provider)
 
     assert count == 1
     assert provider.calls == 1  # the absent figure was never sent to the model

--- a/tests/test_figure_vision.py
+++ b/tests/test_figure_vision.py
@@ -1,0 +1,249 @@
+"""Tests for the vision-LLM figure/chart enrichment pass."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import zlib
+from pathlib import Path
+
+import pytest
+
+from librarian.config import Settings
+from librarian.ingest.extractors import (
+    CompositeExtractor,
+    FigureImage,
+    LiteParseExtractor,
+    enrich_markdown_figures,
+    figure_media_type,
+    liteparse_available,
+)
+from librarian.llm.lazy import LazyLLMProvider
+from librarian.llm.mock import MockLLMProvider
+
+requires_liteparse = pytest.mark.skipif(
+    not liteparse_available(), reason="liteparse extra not installed"
+)
+
+
+class _FakeVision:
+    """Vision provider double that echoes image size and can fail chosen images."""
+
+    name = "fake-vision"
+
+    def __init__(self, *, fail_on: bytes | None = None) -> None:
+        self.fail_on = fail_on
+        self.calls = 0
+
+    async def describe_image(
+        self,
+        *,
+        image_base64: str,
+        media_type: str,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        del media_type, system_prompt, user_prompt, model, max_tokens, temperature
+        self.calls += 1
+        data = base64.b64decode(image_base64)
+        if self.fail_on is not None and data == self.fail_on:
+            raise RuntimeError("vision failed")
+        return f"described {len(data)} bytes"
+
+
+def _fig(fig_id: str, page: int, size: int) -> FigureImage:
+    # Distinct bytes per id (so fail_on can target one figure), exact length size.
+    data = (fig_id.encode("ascii") + bytes(size))[:size]
+    return FigureImage(id=fig_id, page=page, media_type="image/png", data=data)
+
+
+def _enrich(markdown: str, figures: list[FigureImage], provider: _FakeVision, **kw: object):
+    params = {
+        "model": "m",
+        "max_figures": 20,
+        "min_bytes": 2048,
+        "max_bytes": 10_000_000,
+        "max_concurrency": 2,
+        "max_response_chars": 16_000,
+        **kw,
+    }
+    return asyncio.run(enrich_markdown_figures(markdown, figures, provider=provider, **params))  # type: ignore[arg-type]
+
+
+def test_enrich_replaces_placeholders_with_descriptions() -> None:
+    md = "intro\n\n![](image_p1_0.png)\n\nmore\n\n![](image_p2_0.png)\n"
+    figures = [_fig("p1_0", 1, 5000), _fig("p2_0", 2, 4000)]
+
+    out, count = _enrich(md, figures, _FakeVision())
+
+    assert count == 2
+    assert "![](image_p1_0.png)\n\n**Figure (page 1):** described 5000 bytes" in out
+    assert "**Figure (page 2):** described 4000 bytes" in out
+
+
+def test_enrich_respects_max_figures() -> None:
+    md = "![](image_a.png)\n![](image_b.png)\n![](image_c.png)\n"
+    figures = [_fig("a", 1, 5000), _fig("b", 1, 5000), _fig("c", 1, 5000)]
+
+    out, count = _enrich(md, figures, _FakeVision(), max_figures=2)
+
+    assert count == 2
+    assert "image_c.png)\n" in out  # third placeholder left untouched
+    assert out.count("**Figure") == 2
+
+
+def test_enrich_skips_tiny_and_huge_images() -> None:
+    md = "![](image_tiny.png)\n![](image_ok.png)\n![](image_huge.png)\n"
+    figures = [_fig("tiny", 1, 100), _fig("ok", 1, 5000), _fig("huge", 1, 9000)]
+
+    out, count = _enrich(md, figures, _FakeVision(), min_bytes=2048, max_bytes=8000)
+
+    assert count == 1
+    assert "**Figure (page 1):** described 5000 bytes" in out
+
+
+def test_enrich_skips_placeholders_absent_from_markdown() -> None:
+    md = "only one figure here\n\n![](image_present.png)\n"
+    figures = [_fig("present", 1, 5000), _fig("absent", 1, 5000)]
+
+    provider = _FakeVision()
+    out, count = _enrich(md, figures, provider)
+
+    assert count == 1
+    assert provider.calls == 1  # the absent figure was never sent to the model
+
+
+def test_enrich_swallows_per_figure_failure() -> None:
+    md = "![](image_good.png)\n![](image_bad.png)\n"
+    good = _fig("good", 1, 5000)
+    bad = _fig("bad", 2, 5000)
+
+    out, count = _enrich(md, [good, bad], _FakeVision(fail_on=bad.data))
+
+    assert count == 1
+    assert "**Figure (page 1):** described 5000 bytes" in out
+    assert "![](image_bad.png)\n" in out  # failed figure placeholder left as-is
+    assert "**Figure (page 2)" not in out
+
+
+def test_figure_media_type_mapping() -> None:
+    assert figure_media_type("png") == "image/png"
+    assert figure_media_type("JPG") == "image/jpeg"
+    assert figure_media_type(".webp") == "image/webp"
+    assert figure_media_type("tiff") == "image/png"  # unknown -> default png
+
+
+def test_figure_image_placeholder_property() -> None:
+    assert _fig("p3_1", 3, 10).placeholder == "![](image_p3_1.png)"
+
+
+@pytest.mark.asyncio
+async def test_mock_provider_describe_image() -> None:
+    out = await MockLLMProvider().describe_image(
+        image_base64="QUJD",
+        media_type="image/png",
+        system_prompt="s",
+        user_prompt="u",
+        model="m",
+        max_tokens=64,
+        temperature=0.0,
+    )
+    assert "mock description" in out
+
+
+@pytest.mark.asyncio
+async def test_lazy_provider_delegates_describe_image_to_mock() -> None:
+    provider = LazyLLMProvider(Settings(llm_provider="mock"))
+    out = await provider.describe_image(
+        image_base64="QUJD",
+        media_type="image/png",
+        system_prompt="s",
+        user_prompt="u",
+        model="m",
+        max_tokens=64,
+        temperature=0.0,
+    )
+    assert "mock description" in out
+
+
+# --- liteparse integration -------------------------------------------------
+
+
+def _embedded_image_pdf() -> bytes:
+    raw = bytes([255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 0])  # 2x2 RGB
+    img = zlib.compress(raw)
+
+    def obj(n: int, body: bytes) -> bytes:
+        return b"%d 0 obj\n%s\nendobj\n" % (n, body)
+
+    content = b"q 100 0 0 100 50 50 cm /Im0 Do Q\nBT /F1 10 Tf 20 170 Td (Figure 1: sales) Tj ET"
+    objs = [
+        obj(1, b"<< /Type /Catalog /Pages 2 0 R >>"),
+        obj(2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        obj(
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] "
+            b"/Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>",
+        ),
+        obj(4, b"<< /Length %d >>\nstream\n%s\nendstream" % (len(content), content)),
+        obj(
+            5,
+            b"<< /Type /XObject /Subtype /Image /Width 2 /Height 2 /ColorSpace /DeviceRGB "
+            b"/BitsPerComponent 8 /Filter /FlateDecode /Length %d >>\nstream\n%s\nendstream"
+            % (len(img), img),
+        ),
+    ]
+    pdf = b"%PDF-1.4\n"
+    offsets: list[int] = []
+    for body in objs:
+        offsets.append(len(pdf))
+        pdf += body
+    xref = len(pdf)
+    pdf += b"xref\n0 %d\n0000000000 65535 f \n" % (len(objs) + 1)
+    for off in offsets:
+        pdf += b"%010d 00000 n \n" % off
+    pdf += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (
+        len(objs) + 1,
+        xref,
+    )
+    return pdf
+
+
+@requires_liteparse
+def test_liteparse_extractor_enriches_embedded_figure(tmp_path: Path) -> None:
+    source = tmp_path / "fig.pdf"
+    source.write_bytes(_embedded_image_pdf())
+    provider = _FakeVision()
+    extractor = LiteParseExtractor(vision_provider=provider, vision_min_bytes=0)
+
+    markdown = asyncio.run(extractor.extract(source))
+
+    assert provider.calls == 1
+    assert "**Figure (page 1):** described" in markdown
+    assert extractor.last_metadata is not None
+    assert extractor.last_metadata["figures_described"] == 1
+
+
+@requires_liteparse
+def test_liteparse_extractor_without_vision_leaves_placeholder(tmp_path: Path) -> None:
+    source = tmp_path / "fig.pdf"
+    source.write_bytes(_embedded_image_pdf())
+    extractor = LiteParseExtractor()  # no vision provider
+
+    markdown = asyncio.run(extractor.extract(source))
+
+    assert "**Figure (page" not in markdown
+    assert "![](image_" in markdown  # placeholder retained, unenriched
+
+
+@requires_liteparse
+def test_composite_vision_active_and_signature_changes() -> None:
+    plain = CompositeExtractor()
+    with_vision = CompositeExtractor(figure_vision_provider=_FakeVision())
+
+    assert plain.figure_vision_active is False
+    assert with_vision.figure_vision_active is True
+    assert plain.config_signature != with_vision.config_signature


### PR DESCRIPTION
## Summary

Phase 3 of the extractor-upgrade: recover the data that plain extraction loses. liteparse extracts text and tables but leaves figures as image placeholders (`[](image_p1_0.png)`), so chart data vanishes. This adds an **opt-in vision pass** that sends each embedded figure image to a vision-capable model and injects its description — and, for charts, a reconstructed Markdown data table — next to the placeholder, so the numbers flow into the same cleaning / classification / search / OKF pipeline as the rest of the document.

Off by default (`LIBRARIAN_FIGURE_VISION_ENABLED`), since it needs a vision model and adds per-figure cost.

## How it works

- **Providers gained `describe_image`**: the OpenAI-compatible provider sends the image as a vision content part (`data:` URL) through the existing retry/usage path; `MockLLMProvider` returns deterministic output for tests/dry runs; `LazyLLMProvider` and `PromptSizeGuardProvider` forward it.
- **`enrich_markdown_figures`** (new) selects figures whose placeholder is actually present and whose size is in `[min_bytes, max_bytes]`, caps at `max_figures`, describes them with bounded concurrency, and replaces each placeholder with `placeholder + **Figure (page N):** <description>`. **Per-figure failures are swallowed** so one unreadable image never fails the document.
- **`LiteParseExtractor`** runs liteparse in `image_mode="embed"` when vision is on (to get the raw bytes — the markdown placeholders are identical either way), maps `result.images` → `FigureImage`, and enriches. **`CompositeExtractor`** exposes `figure_vision_active` and folds the vision settings into the **extraction-cache config signature**, so toggling vision correctly re-extracts.
- Settings wired through the factory and both API/CLI extractor builders.

## Verification

I confirmed liteparse 2.0.0's behavior empirically before building: `image_mode="embed"` populates `result.images` with `ExtractedImage(id, page, format, bytes)`, and the markdown placeholder is exactly `[](image_{id}.png)`. A test builds a real embedded-image PDF and runs it end-to-end through liteparse + a fake vision provider.

**12 new tests**: enrichment hit / cap / size-skip / absent-skip / per-figure-failure-swallow, media-type mapping, mock + lazy `describe_image`, and the real embedded-image-PDF integration (enriched and unenriched). Full suite **554 passed / 3 skipped**, ruff + pyright clean, **no new dependencies** (`openai` already vendored).

## Scope note

Covers embedded raster figures (the placeholders liteparse emits). Vector-drawn charts that liteparse doesn't surface as embedded images aren't covered yet — a page-screenshot fallback (liteparse `screenshot()`) is the natural follow-up if needed.

