### PR TITLE
Sanity-sweep fixes: cache-signature completeness + convert metadata race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   figure's placeholder so otherwise-lost chart data becomes searchable, classifiable text. Bounded by
   `LIBRARIAN_FIGURE_VISION_MAX_FIGURES`/`_MIN_BYTES`/`_MAX_BYTES`/`_MAX_CONCURRENCY`; uses
   `LIBRARIAN_FIGURE_VISION_MODEL` (defaults to the cleaning model). Per-figure failures are swallowed
-  so one bad image never fails the document, and the vision settings fold into the extraction-cache
-  signature. Providers gained a `describe_image` capability (OpenAI-compatible vision content parts;
+  so one bad image never fails the document, and the output-affecting vision settings (model, figure
+  cap, and the size/length gates) fold into the extraction-cache signature so toggling them
+  re-extracts instead of serving stale text. Providers gained a `describe_image` capability (OpenAI-compatible vision content parts;
   deterministic mock for tests/dry runs).
 - High-fidelity PDF/image extraction via the optional `liteparse` engine
   ([liteparse](https://github.com/run-llama/liteparse), Apache-2.0). When the `liteparse` extra is

--- a/src/librarian/application/convert_document.py
+++ b/src/librarian/application/convert_document.py
@@ -185,16 +185,16 @@ class DocumentConverter:
         if callable(set_page_manifest_path):
             set_page_manifest_path(page_manifest_path if write_sidecar else None)
         text = await self.extractor.extract(source_path)
+        # Capture the extractor's per-run metadata immediately, before any further
+        # await: the extractor instance is shared, so a concurrently-converting
+        # file (parallel imports) would otherwise overwrite last_metadata and the
+        # sidecar would record the wrong source provenance.
+        metadata_obj = getattr(self.extractor, "last_metadata", None)
+        metadata = cast(dict[str, object], metadata_obj) if isinstance(metadata_obj, dict) else None
         rendered = render_conversion(text, source_path=source_path, format=format)
         await asyncio.to_thread(output_path.parent.mkdir, parents=True, exist_ok=True)
         await asyncio.to_thread(_write_text_atomic, output_path, rendered)
         if write_sidecar:
-            metadata_obj = getattr(self.extractor, "last_metadata", None)
-            metadata = (
-                cast(dict[str, object], metadata_obj)
-                if isinstance(metadata_obj, dict)
-                else None
-            )
             await write_conversion_sidecar(
                 source_path=source_path,
                 output_path=output_path,

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -820,11 +820,20 @@ async def enrich_markdown_figures(
     fails the whole extraction. Returns the enriched markdown and the number of
     figures successfully described.
     """
-    eligible = [
-        figure
-        for figure in figures
-        if figure.placeholder in markdown and min_bytes <= len(figure.data) <= max_bytes
-    ][:max_figures]
+    # One placeholder maps to one injection site; if two figures somehow share a
+    # placeholder, keep the first so the replace(count=1) loop can't append the
+    # second figure's description into the first figure's (now re-introduced)
+    # placeholder text.
+    eligible: list[FigureImage] = []
+    seen_placeholders: set[str] = set()
+    for figure in figures:
+        if figure.placeholder in seen_placeholders:
+            continue
+        if figure.placeholder in markdown and min_bytes <= len(figure.data) <= max_bytes:
+            eligible.append(figure)
+            seen_placeholders.add(figure.placeholder)
+        if len(eligible) >= max_figures:
+            break
     if not eligible:
         return markdown, 0
 
@@ -1252,10 +1261,23 @@ class CompositeExtractor:
                 "liteparse_ocr_server_url": liteparse_ocr_server_url,
                 "liteparse_dpi": liteparse_dpi,
                 "liteparse_image_mode": liteparse_image_mode,
+                # Every vision knob that changes which figures are described, or
+                # how much text each yields, must invalidate the cache when the
+                # vision pass is active (gated so toggling unrelated knobs while
+                # vision is off does not churn the cache).
                 "figure_vision": self.figure_vision_active,
                 "figure_vision_model": figure_vision_model if self.figure_vision_active else None,
                 "figure_vision_max_figures": (
                     figure_vision_max_figures if self.figure_vision_active else None
+                ),
+                "figure_vision_min_bytes": (
+                    figure_vision_min_bytes if self.figure_vision_active else None
+                ),
+                "figure_vision_max_bytes": (
+                    figure_vision_max_bytes if self.figure_vision_active else None
+                ),
+                "figure_vision_max_response_chars": (
+                    figure_vision_max_response_chars if self.figure_vision_active else None
                 ),
                 "ocr_language": ocr_language,
                 "ocr_pdf_dpi": ocr_pdf_dpi,
@@ -1266,6 +1288,8 @@ class CompositeExtractor:
                 "ocr_correction_mode": ocr_correction_mode,
                 "ocr_correction_model": ocr_correction_model,
                 "ocr_low_confidence_threshold": ocr_low_confidence_threshold,
+                "ocr_max_correction_response_chars": ocr_max_correction_response_chars,
+                "ocr_fail_on_page_error": ocr_fail_on_page_error,
                 "ocr_correction": ocr_correction_provider is not None,
                 "pdf_max_pages": pdf_max_pages,
                 "pdf_max_input_bytes": pdf_max_input_bytes,

--- a/tests/test_extraction_cache.py
+++ b/tests/test_extraction_cache.py
@@ -145,6 +145,16 @@ def test_composite_config_signature_tracks_engine_change() -> None:
     assert auto.config_signature != legacy.config_signature
 
 
+def test_composite_config_signature_tracks_output_affecting_ocr_options() -> None:
+    base = CompositeExtractor(pdf_engine="legacy")
+    fail_changed = CompositeExtractor(pdf_engine="legacy", ocr_fail_on_page_error=False)
+    resp_changed = CompositeExtractor(
+        pdf_engine="legacy", ocr_max_correction_response_chars=4096
+    )
+    assert base.config_signature != fail_changed.config_signature
+    assert base.config_signature != resp_changed.config_signature
+
+
 def test_extraction_timeout_raises(tmp_path: Path) -> None:
     source = _write(tmp_path, "doc.txt", b"hello world")
     composite = CompositeExtractor(pdf_engine="legacy", extraction_timeout_seconds=1)

--- a/tests/test_figure_vision.py
+++ b/tests/test_figure_vision.py
@@ -129,6 +129,20 @@ def test_enrich_swallows_per_figure_failure() -> None:
     assert "**Figure (page 2)" not in out
 
 
+def test_enrich_dedupes_duplicate_placeholders() -> None:
+    # Two figures resolving to the same placeholder must not both inject (the
+    # second replace(count=1) would otherwise land inside the first's block).
+    md = "![](image_dup.png)\n"
+    figures = [_fig("dup", 1, 5000), _fig("dup", 2, 5000)]
+    provider = _FakeVision()
+
+    out, count = _enrich(md, figures, provider)
+
+    assert count == 1
+    assert provider.calls == 1
+    assert out.count("**Figure") == 1
+
+
 def test_figure_media_type_mapping() -> None:
     assert figure_media_type("png") == "image/png"
     assert figure_media_type("JPG") == "image/jpeg"
@@ -247,3 +261,23 @@ def test_composite_vision_active_and_signature_changes() -> None:
     assert plain.figure_vision_active is False
     assert with_vision.figure_vision_active is True
     assert plain.config_signature != with_vision.config_signature
+
+
+@requires_liteparse
+def test_composite_signature_tracks_vision_size_gates() -> None:
+    # Changing which figures get described (min/max bytes) or how much text each
+    # yields (response cap) must invalidate the extraction cache.
+    base = CompositeExtractor(figure_vision_provider=_FakeVision())
+    min_changed = CompositeExtractor(
+        figure_vision_provider=_FakeVision(), figure_vision_min_bytes=999
+    )
+    max_changed = CompositeExtractor(
+        figure_vision_provider=_FakeVision(), figure_vision_max_bytes=123
+    )
+    resp_changed = CompositeExtractor(
+        figure_vision_provider=_FakeVision(), figure_vision_max_response_chars=512
+    )
+
+    assert base.config_signature != min_changed.config_signature
+    assert base.config_signature != max_changed.config_signature
+    assert base.config_signature != resp_changed.config_signature


### PR DESCRIPTION
## Summary

A fresh-eyes audit of the extractor-upgrade surface (liteparse engine, extraction cache, parallel imports, figure vision) across four dimensions — extractor correctness, config/wiring completeness, storage/import/provider correctness, and docs-vs-code. Every flagged finding was verified by hand (including empirical liteparse checks) before fixing. Three real issues; everything else was clean.

## Fixes

**1. Extraction-cache under-invalidation (correctness).** The `config_signature` omitted options that change emitted text, so changing them and re-ingesting an unchanged file served **stale cached Markdown**. Added the output-affecting figure-vision gates (`min_bytes`, `max_bytes`, `max_response_chars`, gated on vision being active) and the OCR knobs `ocr_fail_on_page_error` and `ocr_max_correction_response_chars`.

**2. Conversion-sidecar metadata race (correctness, default config).** `convert_file` read the shared extractor's `last_metadata` two `await`s after `extract()`. With parallel imports (`import_concurrency` default 2), a concurrently-converting file could overwrite it, so the `.json` sidecar recorded the **wrong source provenance**. Now the metadata is captured immediately after `extract()`, before any further `await`. (Content was never affected — only sidecar provenance.)

**3. Duplicate-placeholder hardening.** `enrich_markdown_figures` now dedupes eligible figures by placeholder, so two figures resolving to the same placeholder can't make the second `replace(count=1)` inject into the first figure's block.

## Verified clean (no change)
- liteparse normalizes embedded images to PNG (a JPEG source still reports `format='png'`), so the hardcoded `.png` placeholder is correct; figures liteparse extracts but doesn't place (e.g. tiny icons) have no markdown placeholder and are correctly skipped.
- Storage (migration `0009`, cache SQL/upsert), import-concurrency (ordering, resume, race-free output paths, failure isolation), and the LLM vision provider plumbing — all clean.
- All 14 new settings are wired consistently across factory + CLI + API construction sites.

## Noted, not fixed (not a defect)
The `/config` API endpoint omits the new extractor-upgrade settings — a pre-existing curation choice (Phase 1/2/2b settings aren't there either), not a bug. Easy to add later as an observability enhancement if you want it.

## Quality
3 new tests (dedup; vision size/response gates change the signature; OCR options change the signature). Full suite **557 passed / 3 skipped**, ruff + **full-repo** pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_