### PR TITLE
Ship the liteparse engine in the Mac app with offline OCR (Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- The macOS app now ships the high-fidelity liteparse engine as its default (the bundled backend
+  already installs the `[all]` extras), with fully offline OCR: the app points liteparse's bundled
+  Tesseract at the same bundled `eng`/`osd` traineddata via the new
+  `LIBRARIAN_LITEPARSE_TESSDATA_PATH` setting, so scanned PDFs are read without any first-use
+  language-data download. `librarian doctor` now reports liteparse availability.
+
 - Vision-LLM figure/chart enrichment (opt-in, `LIBRARIAN_FIGURE_VISION_ENABLED`). With the liteparse
   engine active, each embedded figure image is sent to a vision-capable model that returns a
   description and, for charts, a reconstructed Markdown data table; the result is injected next to the

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ placeholders** and OCRs only the pages that need it, and it bundles its own PDFi
 classification, and OKF pipeline. Set `LIBRARIAN_PDF_ENGINE` to `auto` (default — use liteparse
 when installed, else built-in), `liteparse` (force), or `legacy` (always built-in). Point
 `LIBRARIAN_LITEPARSE_OCR_SERVER_URL` at a Surya/EasyOCR/PaddleOCR server for higher-accuracy OCR.
+liteparse's bundled Tesseract fetches its language data on first use; to run fully offline, set
+`LIBRARIAN_LITEPARSE_TESSDATA_PATH` to a directory of Tesseract `*.traineddata` (the Mac app does
+this automatically, pointing it at its bundled `eng`/`osd` data). The Mac app ships the `[all]`
+extras, so the liteparse engine is the default there with no setup.
 
 ### Figure & chart enrichment (vision)
 

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -56,19 +56,29 @@ releases (built with a Developer ID, see below) open without any warning.
 ## How it works
 
 The app bundles a relocatable Python runtime plus the `nampara-librarian`
-backend in `Librarian.app/Contents/Resources/backend`. On launch it starts
+backend (installed with the `[all]` extras) in
+`Librarian.app/Contents/Resources/backend`. On launch it starts
 `python -m librarian api` on a local port (127.0.0.1 only), waits for
 `/health`, and talks to it over the same public HTTP API any other client
 would use. Quitting the app stops the backend.
+
+Because the backend ships the `[all]` extras, the high-fidelity
+[liteparse](https://github.com/run-llama/liteparse) PDF/image engine — Markdown
+tables, headings, figure placeholders, and selective OCR — is the default
+inside the app, with its own bundled PDFium + Tesseract. No engine selection or
+extra install is needed.
 
 Scanned and image-based PDFs are OCR'd with a self-contained copy of Tesseract
 and Poppler (plus English language data) bundled under
 `Librarian.app/Contents/Resources/ocr`, with dependent libraries relocated into
 the bundle. The app puts these on the engine's `PATH` and sets `TESSDATA_PREFIX`
-at launch — so OCR works with no Homebrew install and no `PATH` setup. (macOS GUI
-apps inherit only a bare system `PATH`, which is why a system-installed OCR tool
-would otherwise be invisible to the engine.) Each DMG is built on a
-native-architecture runner so the bundled OCR binaries match the target Mac.
+at launch — and points the liteparse engine at the same traineddata via
+`LIBRARIAN_LITEPARSE_TESSDATA_PATH` — so OCR (built-in and liteparse) works fully
+offline with no Homebrew install, no `PATH` setup, and no first-use language-data
+download. (macOS GUI apps inherit only a bare system `PATH`, which is why a
+system-installed OCR tool would otherwise be invisible to the engine.) Each DMG
+is built on a native-architecture runner so the bundled OCR binaries match the
+target Mac.
 
 Each launch generates a random API key and passes it to the backend through
 `LIBRARIAN_API_KEY`, so other local processes cannot read or modify your

--- a/apps/macos/Sources/Librarian/BackendController.swift
+++ b/apps/macos/Sources/Librarian/BackendController.swift
@@ -189,6 +189,10 @@ final class BackendController: ObservableObject {
         }
         if let tessdata = Self.bundledTessdataURL {
             environment["TESSDATA_PREFIX"] = tessdata.path
+            // Point the bundled liteparse engine's in-process Tesseract at the
+            // same traineddata so high-fidelity OCR works fully offline instead
+            // of trying to fetch language data on first use.
+            environment["LIBRARIAN_LITEPARSE_TESSDATA_PATH"] = tessdata.path
         }
         let existingPath = environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
         pathEntries.append(existingPath)

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -2455,6 +2455,7 @@ def _build_extractor(
         pdf_max_pages=settings.pdf_max_pages,
         pdf_engine=settings.pdf_engine,
         liteparse_ocr_server_url=settings.liteparse_ocr_server_url,
+        liteparse_tessdata_path=settings.liteparse_tessdata_path,
         liteparse_dpi=settings.liteparse_dpi,
         liteparse_image_mode=settings.liteparse_image_mode,
         figure_vision_provider=(

--- a/src/librarian/application/factory.py
+++ b/src/librarian/application/factory.py
@@ -72,6 +72,7 @@ async def build_ingest_container(
         pdf_max_pages=resolved_settings.pdf_max_pages,
         pdf_engine=resolved_settings.pdf_engine,
         liteparse_ocr_server_url=resolved_settings.liteparse_ocr_server_url,
+        liteparse_tessdata_path=resolved_settings.liteparse_tessdata_path,
         liteparse_dpi=resolved_settings.liteparse_dpi,
         liteparse_image_mode=resolved_settings.liteparse_image_mode,
         figure_vision_provider=(

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -1981,6 +1981,7 @@ def _reject_symlinked_cli_output_path(path: Path) -> None:
 
 def _doctor_module_checks() -> list[tuple[str, str, str, str]]:
     modules = [
+        ("liteparse", "high-fidelity PDF/image extraction", "pip install -e '.[liteparse]'"),
         ("pdfplumber", "embedded PDF extraction", "pip install -e '.[pdf]'"),
         ("pdf2image", "scanned PDF rasterization", "pip install -e '.[ocr]'"),
         ("pytesseract", "OCR confidence diagnostics", "pip install -e '.[ocr]'"),
@@ -2427,6 +2428,7 @@ def _build_extractor(settings: Settings) -> CompositeExtractor:
         pdf_max_pages=settings.pdf_max_pages,
         pdf_engine=settings.pdf_engine,
         liteparse_ocr_server_url=settings.liteparse_ocr_server_url,
+        liteparse_tessdata_path=settings.liteparse_tessdata_path,
         liteparse_dpi=settings.liteparse_dpi,
         liteparse_image_mode=settings.liteparse_image_mode,
         figure_vision_provider=(

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -71,6 +71,10 @@ class Settings(BaseSettings):
     liteparse_ocr_server_url: str | None = Field(default=None)
     liteparse_dpi: int = Field(default=150, gt=0)
     liteparse_image_mode: LiteParseImageMode = Field(default="placeholder")
+    # Directory holding Tesseract traineddata for the liteparse engine's bundled
+    # OCR. Set this to ship fully offline OCR (the Mac app points it at its
+    # bundled tessdata); when unset, liteparse uses its own default lookup.
+    liteparse_tessdata_path: str | None = Field(default=None)
     # Extraction throughput controls. The content-hash extraction cache stores
     # extracted Markdown keyed by file digest + extraction-config signature, so
     # re-ingesting unchanged files (or the same file across documents) skips the

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -885,6 +885,7 @@ class LiteParseExtractor:
         *,
         ocr_language: str = "eng",
         ocr_server_url: str | None = None,
+        tessdata_path: str | None = None,
         dpi: int = 150,
         image_mode: str = "placeholder",
         max_pages: int | None = None,
@@ -899,6 +900,7 @@ class LiteParseExtractor:
     ) -> None:
         self.ocr_language = ocr_language
         self.ocr_server_url = ocr_server_url
+        self.tessdata_path = tessdata_path
         self.dpi = dpi
         self.image_mode = image_mode
         self.max_pages = max_pages
@@ -956,6 +958,7 @@ class LiteParseExtractor:
             ocr_enabled=True,
             ocr_server_url=self.ocr_server_url,
             ocr_language=self.ocr_language,
+            tessdata_path=self.tessdata_path,
             image_mode=image_mode,
             dpi=self.dpi,
             max_pages=self.max_pages,
@@ -1163,6 +1166,7 @@ class CompositeExtractor:
         pdf_max_pages: int = 1_000,
         pdf_engine: str = "auto",
         liteparse_ocr_server_url: str | None = None,
+        liteparse_tessdata_path: str | None = None,
         liteparse_dpi: int = 150,
         liteparse_image_mode: str = "placeholder",
         figure_vision_provider: FigureVisionProvider | None = None,
@@ -1230,6 +1234,7 @@ class CompositeExtractor:
             liteparse_extractor = LiteParseExtractor(
                 ocr_language=ocr_language,
                 ocr_server_url=liteparse_ocr_server_url,
+                tessdata_path=liteparse_tessdata_path,
                 dpi=liteparse_dpi,
                 image_mode=liteparse_image_mode,
                 max_pages=pdf_max_pages,

--- a/tests/test_liteparse_extractor.py
+++ b/tests/test_liteparse_extractor.py
@@ -73,6 +73,63 @@ def test_liteparse_extractor_reconstructs_markdown_table(tmp_path: Path) -> None
 
 
 @requires_liteparse
+def test_liteparse_extractor_forwards_tessdata_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import liteparse
+
+    captured: dict[str, object] = {}
+
+    class _RecordingParser:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def parse(self, _path: str) -> object:
+            class _Result:
+                text = "extracted"
+                images: list[object] = []
+
+            return _Result()
+
+    monkeypatch.setattr(liteparse, "LiteParse", _RecordingParser)
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(_table_pdf_bytes())
+
+    asyncio.run(LiteParseExtractor(tessdata_path="/bundle/tessdata").extract(source))
+
+    assert captured["tessdata_path"] == "/bundle/tessdata"
+
+
+@requires_liteparse
+def test_composite_forwards_liteparse_tessdata_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import liteparse
+
+    captured: dict[str, object] = {}
+
+    class _RecordingParser:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def parse(self, _path: str) -> object:
+            class _Result:
+                text = "extracted"
+                images: list[object] = []
+
+            return _Result()
+
+    monkeypatch.setattr(liteparse, "LiteParse", _RecordingParser)
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(_table_pdf_bytes())
+    composite = CompositeExtractor(liteparse_tessdata_path="/bundle/tessdata")
+
+    asyncio.run(composite.extract(source))
+
+    assert captured["tessdata_path"] == "/bundle/tessdata"
+
+
+@requires_liteparse
 def test_composite_routes_pdf_through_liteparse_by_default(tmp_path: Path) -> None:
     source = tmp_path / "report.pdf"
     source.write_bytes(_table_pdf_bytes())


### PR DESCRIPTION
## Summary

Phase 4 (final phase of the extractor-upgrade): make the macOS app ship the high-fidelity liteparse engine, working **fully offline**.

The pleasant discovery during investigation: most of this was already in place. The app's `bundle_backend.sh` installs the backend with the `[all]` extras — which since Phase 1 includes `liteparse` — so the liteparse wheel (with its in-process PDFium + Tesseract) is **already** downloaded, installed, and code-signed in shipped builds, and the app already bundles `eng`/`osd` traineddata under `Resources/ocr`. The one missing link was pointing liteparse's bundled Tesseract at that traineddata so scanned PDFs OCR offline instead of attempting a first-use language-data download (which would fail in a sandboxed/offline app).

## Changes

- **New `liteparse_tessdata_path` setting**, threaded to `LiteParseExtractor → LiteParse(tessdata_path=...)` and wired through the factory and both API/CLI extractor builders. Deliberately **left out of the extraction-cache signature** — it only says *where* to find the same language data, so it must not invalidate cached output.
- **Mac app**: `BackendController` sets `LIBRARIAN_LITEPARSE_TESSDATA_PATH` to the bundled tessdata dir, next to the existing `TESSDATA_PREFIX`.
- **`librarian doctor`** now reports liteparse availability.
- **Docs**: `apps/macos/README` explains the app ships liteparse as the default with offline OCR; main README documents `LIBRARIAN_LITEPARSE_TESSDATA_PATH`; CHANGELOG.

## Verified before building

- liteparse 2.2.1 publishes **cp312 macOS wheels for both arm64 (`macosx_11_0_arm64`) and Intel (`macosx_10_12_x86_64`)**, and the bundled Python is 3.12.13 — so `pip install wheel[all]` installs it from a prebuilt wheel on **both** arches (the Intel cross-build's `--only-binary=:all:` is satisfied). **No `bundle_backend.sh` change needed.**
- `sign_app.sh` already signs every `.so`/`.dylib` in the backend recursively, covering liteparse's `libpdfium`. **No signing change needed.**
- Empirically confirmed liteparse normalizes embedded images to PNG and exposes `tessdata_path`.

## Tests & quality

New tests: `tessdata_path` is forwarded by both `LiteParseExtractor` and `CompositeExtractor`; `doctor` reports liteparse. Full suite **559 passed / 3 skipped**, ruff + full-repo pyright clean. No new dependencies.

This completes the extractor-upgrade arc: liteparse extraction (Phase 1) → cache + timeout (Phase 2) → parallel imports (Phase 2b) → vision figure enrichment (Phase 3) → Mac app delivery (Phase 4).

