### PR TITLE
Auto-orient rotated images/scans before OCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Sideways and upside-down images and scans now extract real text instead of garbage: before OCR,
+  Librarian auto-rotates pages upright using Tesseract's orientation detection (`osd.traineddata`),
+  applying the rotation only when detection is confident so a correctly-oriented page is never
+  flipped. On by default for both standalone images and scanned PDF pages; disable with
+  `LIBRARIAN_OCR_AUTO_ORIENT=false`. Best-effort and graceful — if orientation can't be determined
+  (e.g. too little text, OSD data unavailable), the page is left as-is.
+
 ## 1.7.0 - 2026-06-26
 
 - The macOS app now ships the high-fidelity liteparse engine as its default (the bundled backend

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ sudo apt-get install -y tesseract-ocr poppler-utils  # Debian/Ubuntu
 Without them, text-layer PDFs still work; scanned pages can't be read by the fallback path. Run
 `librarian doctor` to see exactly what's available.
 
+**Rotated scans** are handled automatically: sideways or upside-down images and pages are detected
+with Tesseract's orientation detection and rotated upright before OCR, so they yield real text
+instead of garbage (it only rotates when detection is confident, never flipping a correct page).
+On by default; set `LIBRARIAN_OCR_AUTO_ORIENT=false` to disable.
+
 ---
 
 ## ⌨️ CLI reference (every command)

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -2442,6 +2442,7 @@ def _build_extractor(
         ocr_threshold=settings.ocr_threshold,
         ocr_preserve_page_images=settings.ocr_preserve_page_images,
         ocr_rotation_retry=settings.ocr_rotation_retry,
+        ocr_auto_orient=settings.ocr_auto_orient,
         ocr_correction_provider=LazyLLMProvider(settings, metrics=metrics),
         ocr_correction_mode=settings.ocr_llm_correction,
         ocr_correction_model=settings.ocr_llm_model or settings.llm_model,

--- a/src/librarian/application/factory.py
+++ b/src/librarian/application/factory.py
@@ -59,6 +59,7 @@ async def build_ingest_container(
         ocr_threshold=resolved_settings.ocr_threshold,
         ocr_preserve_page_images=resolved_settings.ocr_preserve_page_images,
         ocr_rotation_retry=resolved_settings.ocr_rotation_retry,
+        ocr_auto_orient=resolved_settings.ocr_auto_orient,
         ocr_correction_provider=LazyLLMProvider(resolved_settings, metrics=metrics),
         ocr_correction_mode=resolved_settings.ocr_llm_correction,
         ocr_correction_model=resolved_settings.ocr_llm_model or resolved_settings.llm_model,

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -2415,6 +2415,7 @@ def _build_extractor(settings: Settings) -> CompositeExtractor:
         ocr_threshold=settings.ocr_threshold,
         ocr_preserve_page_images=settings.ocr_preserve_page_images,
         ocr_rotation_retry=settings.ocr_rotation_retry,
+        ocr_auto_orient=settings.ocr_auto_orient,
         ocr_correction_provider=LazyLLMProvider(settings),
         ocr_correction_mode=settings.ocr_llm_correction,
         ocr_correction_model=settings.ocr_llm_model or settings.llm_model,

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -109,6 +109,11 @@ class Settings(BaseSettings):
     ocr_threshold: int = Field(default=180, ge=0, le=255)
     ocr_preserve_page_images: bool = Field(default=False)
     ocr_rotation_retry: bool = Field(default=False)
+    # Auto-rotate sideways/upside-down scans upright (Tesseract OSD) before OCR,
+    # so rotated images and pages extract real text instead of garbage. On by
+    # default; best-effort (leaves the image untouched if orientation can't be
+    # determined).
+    ocr_auto_orient: bool = Field(default=True)
     ocr_llm_correction: OcrLlmCorrectionMode = Field(default="always")
     ocr_llm_model: str | None = Field(default=None)
     ocr_low_confidence_threshold: float = Field(default=85.0, ge=0, le=100)

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 import multiprocessing
 import queue
+import re
 import shutil
 import subprocess
 import tempfile
@@ -221,6 +222,7 @@ class PdfExtractor:
         ocr_threshold: int = 180,
         ocr_preserve_page_images: bool = False,
         ocr_rotation_retry: bool = False,
+        ocr_auto_orient: bool = True,
         ocr_correction_provider: OcrCorrectionProvider | None = None,
         ocr_correction_mode: OcrCorrectionMode = "always",
         ocr_correction_model: str = "mock-cleaner",
@@ -241,6 +243,7 @@ class PdfExtractor:
         self.ocr_threshold = ocr_threshold
         self.ocr_preserve_page_images = ocr_preserve_page_images
         self.ocr_rotation_retry = ocr_rotation_retry
+        self.ocr_auto_orient = ocr_auto_orient
         self.ocr_correction_provider = ocr_correction_provider
         self.ocr_correction_mode = ocr_correction_mode
         self.ocr_correction_model = ocr_correction_model
@@ -335,6 +338,7 @@ class PdfExtractor:
                         image_artifact_path=self._ocr_page_image_artifact_path(page_number),
                         rotation_retry=self.ocr_rotation_retry,
                         low_confidence_threshold=self.ocr_low_confidence_threshold,
+                        auto_orient=self.ocr_auto_orient,
                     )
                     ocr_result = _coerce_ocr_result(ocr_result_obj)
                     correction = await self._correct_ocr_page(
@@ -514,6 +518,7 @@ class PdfExtractor:
                         image_artifact_path=None,
                         rotation_retry=self.ocr_rotation_retry,
                         low_confidence_threshold=self.ocr_low_confidence_threshold,
+                        auto_orient=self.ocr_auto_orient,
                     )
                 )
             except (RuntimeError, ValueError) as exc:
@@ -652,12 +657,14 @@ class ImageOcrExtractor:
         timeout_seconds: int = 120,
         preprocess_mode: OcrPreprocessMode = "none",
         threshold: int = 180,
+        auto_orient: bool = True,
     ) -> None:
         self.language = language
         self.timeout_seconds = timeout_seconds
         _validate_ocr_preprocess_config(preprocess_mode, threshold=threshold)
         self.preprocess_mode: OcrPreprocessMode = preprocess_mode
         self.threshold = threshold
+        self.auto_orient = auto_orient
 
     async def extract(self, path: Path) -> str:
         return await asyncio.to_thread(
@@ -667,6 +674,7 @@ class ImageOcrExtractor:
             timeout_seconds=self.timeout_seconds,
             preprocess_mode=self.preprocess_mode,
             threshold=self.threshold,
+            auto_orient=self.auto_orient,
         )
 
 
@@ -1153,6 +1161,7 @@ class CompositeExtractor:
         ocr_threshold: int = 180,
         ocr_preserve_page_images: bool = False,
         ocr_rotation_retry: bool = False,
+        ocr_auto_orient: bool = True,
         ocr_correction_provider: OcrCorrectionProvider | None = None,
         ocr_correction_mode: OcrCorrectionMode = "always",
         ocr_correction_model: str = "mock-cleaner",
@@ -1190,6 +1199,7 @@ class CompositeExtractor:
             ocr_threshold=ocr_threshold,
             ocr_preserve_page_images=ocr_preserve_page_images,
             ocr_rotation_retry=ocr_rotation_retry,
+            ocr_auto_orient=ocr_auto_orient,
             ocr_correction_provider=ocr_correction_provider,
             ocr_correction_mode=ocr_correction_mode,
             ocr_correction_model=ocr_correction_model,
@@ -1206,6 +1216,7 @@ class CompositeExtractor:
             timeout_seconds=ocr_timeout_seconds,
             preprocess_mode=ocr_preprocess_mode,
             threshold=ocr_threshold,
+            auto_orient=ocr_auto_orient,
         )
         extractors = [
             TextFamilyExtractor(max_input_bytes=text_max_input_bytes),
@@ -1290,6 +1301,7 @@ class CompositeExtractor:
                 "ocr_preprocess_mode": ocr_preprocess_mode,
                 "ocr_threshold": ocr_threshold,
                 "ocr_rotation_retry": ocr_rotation_retry,
+                "ocr_auto_orient": ocr_auto_orient,
                 "ocr_correction_mode": ocr_correction_mode,
                 "ocr_correction_model": ocr_correction_model,
                 "ocr_low_confidence_threshold": ocr_low_confidence_threshold,
@@ -1343,13 +1355,22 @@ def _ocr_image(
     timeout_seconds: int = 120,
     preprocess_mode: OcrPreprocessMode = "none",
     threshold: int = 180,
+    auto_orient: bool = True,
 ) -> str:
     tesseract_path = shutil.which("tesseract")
     if tesseract_path is None:
         raise RuntimeError("OCR requires the 'tesseract' executable on PATH")
     with tempfile.TemporaryDirectory() as tmp_dir:
+        source_path = path
+        if auto_orient:
+            source_path = auto_orient_image(
+                path,
+                tesseract_path=tesseract_path,
+                timeout_seconds=timeout_seconds,
+                output_dir=Path(tmp_dir),
+            )
         prepared_path = _prepare_ocr_image(
-            path,
+            source_path,
             output_dir=Path(tmp_dir),
             preprocess_mode=preprocess_mode,
             threshold=threshold,
@@ -1373,13 +1394,22 @@ def _ocr_image_result(
     timeout_seconds: int = 120,
     preprocess_mode: OcrPreprocessMode = "none",
     threshold: int = 180,
+    auto_orient: bool = True,
 ) -> OcrTextResult:
     tesseract_path = shutil.which("tesseract")
     if tesseract_path is None:
         raise RuntimeError("OCR requires the 'tesseract' executable on PATH")
     with tempfile.TemporaryDirectory() as tmp_dir:
+        source_path = path
+        if auto_orient:
+            source_path = auto_orient_image(
+                path,
+                tesseract_path=tesseract_path,
+                timeout_seconds=timeout_seconds,
+                output_dir=Path(tmp_dir),
+            )
         prepared_path = _prepare_ocr_image(
-            path,
+            source_path,
             output_dir=Path(tmp_dir),
             preprocess_mode=preprocess_mode,
             threshold=threshold,
@@ -1441,6 +1471,68 @@ def _run_tesseract(
         text=True,
         timeout=timeout_seconds,
     )
+
+
+_OSD_ROTATE_RE = re.compile(r"^Rotate:\s*(\d+)", re.MULTILINE)
+_OSD_CONFIDENCE_RE = re.compile(r"^Orientation confidence:\s*([\d.]+)", re.MULTILINE)
+# Tesseract OSD reports a clear orientation at confidence ~3-5; ambiguous or
+# text-sparse pages score well under 1. Require a modest floor so a correctly
+# oriented image is never flipped on a low-confidence guess.
+_OSD_MIN_CONFIDENCE = 1.5
+
+
+def auto_orient_image(
+    path: Path,
+    *,
+    tesseract_path: str,
+    timeout_seconds: int,
+    output_dir: Path,
+) -> Path:
+    """Rotate an image upright using Tesseract OSD before OCR (best effort).
+
+    A sideways or upside-down scan otherwise OCRs to garbage. Tesseract's
+    orientation/script detection (``osd.traineddata``) reports how many degrees
+    the page must rotate clockwise to read upright; we apply that with Pillow
+    only when OSD is confident. Any failure -- OSD data missing, too few
+    characters to decide, low confidence, Pillow not installed, a malformed
+    image -- leaves the original untouched, so this can never make extraction
+    worse than the un-oriented pass.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603
+            [tesseract_path, str(path), "stdout", "--psm", "0"],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return path
+    output = completed.stdout or ""
+    match = _OSD_ROTATE_RE.search(output)
+    if match is None:
+        return path
+    degrees = int(match.group(1)) % 360
+    if degrees == 0:
+        return path
+    confidence_match = _OSD_CONFIDENCE_RE.search(output)
+    confidence = float(confidence_match.group(1)) if confidence_match else 0.0
+    if confidence < _OSD_MIN_CONFIDENCE:
+        return path
+    try:
+        image_module = importlib.import_module("PIL.Image")
+    except ImportError:
+        return path
+    try:
+        with image_module.open(path) as image:
+            # OSD reports clockwise degrees-to-upright; Pillow rotates counter-
+            # clockwise, so negate. ``expand`` keeps the whole rotated canvas.
+            oriented = image.rotate(-degrees, expand=True, fillcolor="white")
+            oriented_path = output_dir / f"{path.stem}.ocr-oriented.png"
+            oriented.save(oriented_path)
+    except Exception:  # noqa: BLE001 - orientation is best-effort
+        return path
+    return oriented_path
 
 
 def _prepare_ocr_image(
@@ -1604,6 +1696,7 @@ def _ocr_pdf_page(
     image_artifact_path: Path | None = None,
     rotation_retry: bool = False,
     low_confidence_threshold: float = 85.0,
+    auto_orient: bool = True,
 ) -> OcrTextResult:
     if shutil.which("tesseract") is None:
         raise RuntimeError("Scanned PDF OCR requires the 'tesseract' executable on PATH")
@@ -1636,6 +1729,7 @@ def _ocr_pdf_page(
                 rotation_retry=rotation_retry,
                 low_confidence_threshold=low_confidence_threshold,
                 output_dir=Path(tmp_dir),
+                auto_orient=auto_orient,
             )
             for image_path in image_paths
         ]
@@ -1672,6 +1766,7 @@ def _ocr_image_result_with_rotation_retry(
     rotation_retry: bool,
     low_confidence_threshold: float,
     output_dir: Path,
+    auto_orient: bool = True,
 ) -> OcrTextResult:
     original = _ocr_image_result(
         path,
@@ -1679,6 +1774,7 @@ def _ocr_image_result_with_rotation_retry(
         timeout_seconds=timeout_seconds,
         preprocess_mode=preprocess_mode,
         threshold=threshold,
+        auto_orient=auto_orient,
     )
     if not rotation_retry or _ocr_confidence_is_usable(
         original.confidence,
@@ -1696,6 +1792,8 @@ def _ocr_image_result_with_rotation_retry(
                 timeout_seconds=timeout_seconds,
                 preprocess_mode=preprocess_mode,
                 threshold=threshold,
+                # Don't let OSD undo the deliberate brute-force rotation.
+                auto_orient=False,
             )
         except (RuntimeError, ValueError, subprocess.SubprocessError):
             continue

--- a/tests/test_ocr_orientation.py
+++ b/tests/test_ocr_orientation.py
@@ -1,0 +1,154 @@
+"""Tests for OSD-based auto-orientation of rotated images before OCR."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from librarian.ingest import extractors
+from librarian.ingest.extractors import ImageOcrExtractor, auto_orient_image
+
+
+def _osd_output(rotate: int, confidence: float) -> str:
+    return (
+        "Page number: 0\n"
+        f"Orientation in degrees: {(360 - rotate) % 360}\n"
+        f"Rotate: {rotate}\n"
+        f"Orientation confidence: {confidence}\n"
+        "Script: Latin\n"
+        "Script confidence: 5.00\n"
+    )
+
+
+def _fake_osd(
+    rotate: int, confidence: float
+) -> Callable[..., subprocess.CompletedProcess[str]]:
+    def run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        del kwargs
+        out = _osd_output(rotate, confidence)
+        return subprocess.CompletedProcess(cmd, 0, stdout=out, stderr="")
+
+    return run
+
+
+def _landscape_png(tmp_path: Path) -> Path:
+    image_module = pytest.importorskip("PIL.Image")
+    src = tmp_path / "img.png"
+    image_module.new("RGB", (300, 100), "white").save(src)
+    return src
+
+
+def test_auto_orient_rotates_on_confident_osd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    image_module = pytest.importorskip("PIL.Image")
+    src = _landscape_png(tmp_path)
+    monkeypatch.setattr(extractors.subprocess, "run", _fake_osd(90, 4.6))
+
+    out = auto_orient_image(
+        src, tesseract_path="/usr/bin/tesseract", timeout_seconds=30, output_dir=tmp_path
+    )
+
+    assert out != src
+    with image_module.open(out) as oriented:
+        assert oriented.size == (100, 300)  # 90° rotation swaps the dimensions
+
+
+def test_auto_orient_skips_low_confidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("PIL.Image")
+    src = _landscape_png(tmp_path)
+    monkeypatch.setattr(extractors.subprocess, "run", _fake_osd(90, 0.4))
+
+    out = auto_orient_image(
+        src, tesseract_path="/usr/bin/tesseract", timeout_seconds=30, output_dir=tmp_path
+    )
+
+    assert out == src  # a shaky guess must not flip a possibly-correct image
+
+
+def test_auto_orient_noop_on_zero_rotation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("PIL.Image")
+    src = _landscape_png(tmp_path)
+    monkeypatch.setattr(extractors.subprocess, "run", _fake_osd(0, 9.0))
+
+    out = auto_orient_image(
+        src, tesseract_path="/usr/bin/tesseract", timeout_seconds=30, output_dir=tmp_path
+    )
+
+    assert out == src
+
+
+def test_auto_orient_graceful_when_osd_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("PIL.Image")
+    src = _landscape_png(tmp_path)
+
+    def boom(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        del cmd, kwargs
+        raise OSError("tesseract exploded")
+
+    monkeypatch.setattr(extractors.subprocess, "run", boom)
+
+    out = auto_orient_image(
+        src, tesseract_path="/usr/bin/tesseract", timeout_seconds=30, output_dir=tmp_path
+    )
+
+    assert out == src  # never worse than the un-oriented pass
+
+
+# --- real OSD integration --------------------------------------------------
+
+
+def _osd_functional() -> bool:
+    tesseract = shutil.which("tesseract")
+    if tesseract is None:
+        return False
+    try:
+        result = subprocess.run(  # noqa: S603
+            [tesseract, "--list-langs"], capture_output=True, text=True, timeout=20, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "osd" in (result.stdout + result.stderr)
+
+
+def _document_image(tmp_path: Path, *, rotate: int):
+    image_module = pytest.importorskip("PIL.Image")
+    from PIL import ImageDraw, ImageFont
+
+    image = image_module.new("RGB", (900, 420), "white")
+    draw = ImageDraw.Draw(image)
+    try:
+        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 30)
+    except OSError:
+        font = ImageFont.load_default()
+    lines = [
+        "The quarterly revenue report shows strong growth",
+        "across every region this fiscal year.",
+        "Operating margins improved while costs declined,",
+        "and the board approved a new dividend policy.",
+    ]
+    for index, line in enumerate(lines):
+        draw.text((20, 20 + index * 70), line, fill="black", font=font)
+    path = tmp_path / f"doc_{rotate}.png"
+    image.rotate(rotate, expand=True, fillcolor="white").save(path)
+    return path
+
+
+@pytest.mark.skipif(not _osd_functional(), reason="tesseract OSD data not available")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rotate", [90, 180, 270])
+async def test_rotated_document_ocr_recovered_by_auto_orient(tmp_path: Path, rotate: int) -> None:
+    path = _document_image(tmp_path, rotate=rotate)
+
+    oriented = await ImageOcrExtractor(auto_orient=True).extract(path)
+
+    # The upright text is recovered regardless of how the page was rotated.
+    assert "revenue" in oriented.lower()
+    assert "dividend" in oriented.lower()


### PR DESCRIPTION
## The bug

Sideways or upside-down images extracted to garbage. I traced it: the image OCR path ran a **single Tesseract pass with no orientation handling**, and on the **Mac app, standalone images fall back to that path** — liteparse needs ImageMagick to handle loose images, which the app doesn't bundle, so images route to the built-in OCR. A 90/180/270° scan therefore produced unreadable text.

## Investigation (empirical)

- Reproduced: liteparse errors on standalone images without ImageMagick → fallback to the legacy single-pass OCR → no rotation handling.
- Confirmed **Tesseract OSD works perfectly with the already-bundled `osd.traineddata`**: `Rotate: 90` for sideways, `Rotate: 180` for upside-down, at confidence ~4.6 on real text (and <1 on ambiguous/sparse pages — hence the confidence gate).

## The fix

Before OCR, detect orientation with Tesseract OSD and rotate the page upright with Pillow.

- **`auto_orient_image`** helper: runs `tesseract --psm 0`, parses the clockwise `Rotate` degrees **and** the orientation confidence, and rotates **only when confidence clears a floor (1.5)** — so a correctly-oriented page is never flipped on a shaky guess. Any failure (OSD data missing, too few characters, low confidence, Pillow absent, malformed image) leaves the page untouched, so it can **never do worse** than the un-oriented pass.
- Applied to **both** the standalone image path and **scanned PDF pages**; the brute-force rotation-retry candidates skip auto-orient so OSD can't undo their deliberate rotation.
- New **`ocr_auto_orient`** setting (`LIBRARIAN_OCR_AUTO_ORIENT`, default **on**), threaded through `ImageOcrExtractor` / `PdfExtractor` / `CompositeExtractor` / factory / CLI / API, and folded into the extraction-cache signature.

## Verification

Empirically: a 90°- and 180°-rotated multi-line document recovers **all** keywords with auto-orient on and **none** with it off, while an already-upright page is unchanged.

Tests: deterministic unit tests (monkeypatched OSD) for rotate / low-confidence-skip / zero-rotation no-op / graceful-failure, plus a real-OSD integration test (90/180/270°). Full suite **566 passed / 3 skipped**, ruff + full-repo pyright clean. No new dependencies.

## Note on coverage

OSD needs *some* text to judge orientation (it reports "too few characters" on near-empty images), so a sideways photo with only a word or two may not auto-rotate — by design, since forcing a low-confidence rotation risks flipping a correct page. Real document scans (the reported case) have ample text and orient reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_