### PR TITLE
Run standalone images through liteparse via a Pillow PDF shim (no ImageMagick)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Standalone images (PNG/JPG/scans) now get the full liteparse pipeline — reconstructed tables,
+  headings, and figures — instead of flat OCR text. liteparse needs a PDF to do this and normally
+  shells out to ImageMagick to convert an image; Librarian does the conversion with Pillow (already
+  bundled) and orients the image upright first, so images extract at the same fidelity as PDFs with
+  no ImageMagick dependency. The built-in OCR path remains the per-image fallback.
 - Sideways and upside-down images and scans now extract real text instead of garbage: before OCR,
   Librarian auto-rotates pages upright using Tesseract's orientation detection (`osd.traineddata`),
   applying the rotation only when detection is confident so a correctly-oriented page is never

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ With the `liteparse` extra (included in `[all]`), Librarian extracts PDFs and im
 [liteparse](https://github.com/run-llama/liteparse) (Apache-2.0) — reconstructed **Markdown tables,
 headings, lists, and figure placeholders**, with selective OCR and its own bundled PDFium +
 Tesseract (no `poppler` needed). The built-in `pdfplumber` + Tesseract path stays as a per-document
-fallback.
+fallback. Standalone images (PNG/JPG/scans) get the same treatment: Librarian converts them to a
+one-page PDF with Pillow (oriented upright first) and runs them through liteparse — no ImageMagick
+required.
 
 | Capability | How to turn it on | What it does |
 | --- | --- | --- |

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -898,6 +898,8 @@ class LiteParseExtractor:
         image_mode: str = "placeholder",
         max_pages: int | None = None,
         max_input_bytes: int = 200 * 1024 * 1024,
+        ocr_timeout_seconds: int = 120,
+        auto_orient: bool = True,
         vision_provider: FigureVisionProvider | None = None,
         vision_model: str = "mock-cleaner",
         vision_max_figures: int = 20,
@@ -913,6 +915,8 @@ class LiteParseExtractor:
         self.image_mode = image_mode
         self.max_pages = max_pages
         self.max_input_bytes = max_input_bytes
+        self.ocr_timeout_seconds = ocr_timeout_seconds
+        self.auto_orient = auto_orient
         self.vision_provider = vision_provider
         self.vision_model = vision_model
         self.vision_max_figures = vision_max_figures
@@ -972,7 +976,22 @@ class LiteParseExtractor:
             max_pages=self.max_pages,
             quiet=True,
         )
-        result = parser.parse(str(path))
+        # liteparse parses PDFs natively but converts loose images to PDF first,
+        # which needs ImageMagick. Do that conversion ourselves with Pillow (after
+        # orienting the image upright) so images get the full liteparse pipeline
+        # -- tables, headings, figures -- with no ImageMagick dependency.
+        if path.suffix.lower() in IMAGE_EXTENSIONS:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                pdf_path = _image_to_single_page_pdf(
+                    path,
+                    output_dir=Path(tmp_dir),
+                    auto_orient=self.auto_orient,
+                    ocr_timeout_seconds=self.ocr_timeout_seconds,
+                )
+                return self._collect_result(parser.parse(str(pdf_path)))
+        return self._collect_result(parser.parse(str(path)))
+
+    def _collect_result(self, result: Any) -> tuple[str, list[FigureImage]]:
         figures: list[FigureImage] = []
         if self.vision_provider is not None:
             for image in result.images:
@@ -1250,6 +1269,8 @@ class CompositeExtractor:
                 image_mode=liteparse_image_mode,
                 max_pages=pdf_max_pages,
                 max_input_bytes=pdf_max_input_bytes,
+                ocr_timeout_seconds=ocr_timeout_seconds,
+                auto_orient=ocr_auto_orient,
                 vision_provider=figure_vision_provider,
                 vision_model=figure_vision_model,
                 vision_max_figures=figure_vision_max_figures,
@@ -1533,6 +1554,46 @@ def auto_orient_image(
     except Exception:  # noqa: BLE001 - orientation is best-effort
         return path
     return oriented_path
+
+
+def _image_to_single_page_pdf(
+    image_path: Path,
+    *,
+    output_dir: Path,
+    auto_orient: bool,
+    ocr_timeout_seconds: int,
+) -> Path:
+    """Render a loose image as a one-page PDF so liteparse can parse it.
+
+    liteparse handles PDFs natively but shells out to ImageMagick to turn a
+    standalone image into a PDF first. Doing the conversion with Pillow (already
+    available via the ``ocr`` extra and bundled in the Mac app) gives images the
+    full liteparse pipeline -- tables, headings, figures -- without that
+    heavyweight dependency. The image is oriented upright first so rotated
+    photos and scans extract correctly.
+    """
+    try:
+        image_module = importlib.import_module("PIL.Image")
+    except ImportError as exc:
+        raise RuntimeError(
+            "liteparse image extraction requires Pillow (install the 'ocr' extra)"
+        ) from exc
+    source = image_path
+    if auto_orient:
+        tesseract_path = shutil.which("tesseract")
+        if tesseract_path is not None:
+            source = auto_orient_image(
+                image_path,
+                tesseract_path=tesseract_path,
+                timeout_seconds=ocr_timeout_seconds,
+                output_dir=output_dir,
+            )
+    pdf_path = output_dir / f"{image_path.stem}.liteparse.pdf"
+    with image_module.open(source) as image:
+        # Flatten onto white so transparency does not become a black page.
+        rgb = image.convert("RGB")
+        rgb.save(pdf_path, "PDF", resolution=200.0)
+    return pdf_path
 
 
 def _prepare_ocr_image(

--- a/tests/test_liteparse_extractor.py
+++ b/tests/test_liteparse_extractor.py
@@ -1,6 +1,7 @@
 """Tests for the optional liteparse-backed extraction engine."""
 
 import asyncio
+import shutil
 from pathlib import Path
 
 import pytest
@@ -183,3 +184,61 @@ def test_fallback_extractor_uses_legacy_on_primary_failure(tmp_path: Path) -> No
 
     assert result == "legacy extracted text"
     assert fallback.last_metadata == {"engine": "legacy"}
+
+
+def _text_image_png(tmp_path: Path, *, rotate: int = 0) -> Path:
+    image_module = pytest.importorskip("PIL.Image")
+    from PIL import ImageDraw, ImageFont
+
+    image = image_module.new("RGB", (820, 300), "white")
+    draw = ImageDraw.Draw(image)
+    try:
+        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 30)
+    except OSError:
+        font = ImageFont.load_default()
+    for index, line in enumerate(
+        ["The annual report summarizes revenue", "and dividend policy for shareholders."]
+    ):
+        draw.text((25, 40 + index * 90), line, fill="black", font=font)
+    path = tmp_path / f"report_{rotate}.png"
+    image.rotate(rotate, expand=True, fillcolor="white").save(path)
+    return path
+
+
+@requires_liteparse
+def test_liteparse_extracts_image_without_imagemagick(tmp_path: Path) -> None:
+    pytest.importorskip("PIL.Image")
+    source = _text_image_png(tmp_path)
+
+    # liteparse cannot ingest a loose image without ImageMagick; the extractor
+    # converts it to a one-page PDF with Pillow first, so this must succeed.
+    markdown = asyncio.run(LiteParseExtractor().extract(source))
+
+    assert "revenue" in markdown.lower()
+    assert "dividend" in markdown.lower()
+
+
+@requires_liteparse
+def test_composite_routes_image_through_liteparse(tmp_path: Path) -> None:
+    pytest.importorskip("PIL.Image")
+    source = _text_image_png(tmp_path)
+
+    composite = CompositeExtractor()
+    markdown = asyncio.run(composite.extract(source))
+
+    assert "revenue" in markdown.lower()
+    assert composite.last_metadata is not None
+    assert composite.last_metadata["engine"] == "liteparse"
+
+
+@requires_liteparse
+@pytest.mark.skipif(shutil.which("tesseract") is None, reason="no system tesseract")
+def test_liteparse_image_shim_orients_rotated_scan(tmp_path: Path) -> None:
+    pytest.importorskip("PIL.Image")
+    source = _text_image_png(tmp_path, rotate=180)
+
+    markdown = asyncio.run(LiteParseExtractor(auto_orient=True).extract(source))
+
+    # Upright text recovered from an upside-down image (OSD orients before OCR).
+    assert "revenue" in markdown.lower()
+    assert "dividend" in markdown.lower()


### PR DESCRIPTION
## Summary

Standalone images (PNG/JPG/scans) now get the **full liteparse pipeline** — reconstructed tables, headings, figures, selective OCR — instead of flat built-in OCR, and **without bundling ImageMagick**.

### Why
liteparse parses PDFs natively but shells out to **ImageMagick** to turn a loose image into a PDF first. The Mac app (and any install without ImageMagick) therefore had images fall back to the basic Tesseract OCR path. Rather than bundle ImageMagick (a large binary + a big delegate-library tree + a real CVE history), we do the image→PDF conversion ourselves with **Pillow** — already bundled via the `ocr` extra and in the Mac app.

### How
`LiteParseExtractor` now detects an image input, **orients it upright with OSD** (carrying over the #46 auto-orient fix), saves it as a **one-page PDF at 200 dpi** with Pillow, and runs liteparse on that PDF. The built-in OCR path stays as the per-image fallback (e.g. if Pillow is unavailable).

- New `_image_to_single_page_pdf` helper; `LiteParseExtractor` gains `auto_orient` + `ocr_timeout_seconds`, threaded from `CompositeExtractor`'s existing `ocr_auto_orient` / `ocr_timeout_seconds` (already wired through config / factory / CLI / API and folded into the extraction-cache signature).

### Proven before/after
- A loose image that liteparse rejects directly (`ImageMagick is not installed`) extracts cleanly through the shim — **including a reconstructed Markdown table** in my manual check.
- A **180°-rotated** image recovers **3/3 keywords** with auto-orient on vs **0/3** off, through the liteparse path.
- `CompositeExtractor` reports `engine=liteparse` for images (no longer the fallback).

> Note: liteparse's table detection is borderline on *synthetic* text-drawn images (a long-standing quirk of the test fixtures), so the new tests assert text/engine rather than table shape; the Phase 1 PDF-table test already covers reliable table reconstruction.

