### PR TITLE
Release 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.7.1 - 2026-06-26
 
 - Standalone images (PNG/JPG/scans) now get the full liteparse pipeline — reconstructed tables,
   headings, and figures — instead of flat OCR text. liteparse needs a PDF to do this and normally

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ own machine.
 > exportable library. The extractor is best-in-class; the **clean-up and organization are what make
 > it Librarian**.
 
-Version `1.7.0` is the stable production release. Everything runs locally by default — source files
+Version `1.7.1` is the stable production release. Everything runs locally by default — source files
 and generated outputs live in a SQLite-backed workspace on your disk, and text leaves your machine
 only when *you* point cleaning, classification, or OCR-correction at an external model provider.
 
@@ -61,7 +61,7 @@ pip install "nampara-librarian[all]"      # [all] pulls every optional capabilit
 librarian doctor                          # confirm what's available
 ```
 
-> From a release wheel: `pip install "nampara_librarian-1.7.0-py3-none-any.whl[all]"` ·
+> From a release wheel: `pip install "nampara_librarian-1.7.1-py3-none-any.whl[all]"` ·
 > From a checkout: `pip install -e ".[dev,all]"`
 
 ---

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ import root:
 docker run --rm -p 8080:8080 \
   -e LIBRARIAN_API_KEY=change-me \
   -e LIBRARIAN_API_IMPORT_ROOT=/data/imports \
-  ghcr.io/nampara-ai/librarian:v1.7.0
+  ghcr.io/nampara-ai/librarian:v1.7.1
 ```
 
 ## Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nampara-librarian"
-version = "1.7.0"
+version = "1.7.1"
 description = "Local-first corpus cleaner and library organizer with CLI and API surfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/librarian/version.py
+++ b/src/librarian/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -74,7 +74,7 @@ def test_release_docs_describe_stable_surface() -> None:
     operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Version `1.7.0` is the stable production release." in readme
+    assert "Version `1.7.1` is the stable production release." in readme
     assert "librarian admin page-manifest" in operations
     assert "librarian maintainer eval" in operations
     assert "## 1.0.0 - 2026-05-22" in changelog


### PR DESCRIPTION
## Release 1.7.1

Bug-fix / enhancement release — ships the two image-quality improvements already merged to `main`:

- **Auto-orient sideways/upside-down images and scans before OCR** (#46) — confidence-gated OSD, on by default.
- **Run standalone images through liteparse via a Pillow image→PDF shim** (#47) — images get full table/structure extraction with no ImageMagick dependency.

### What's in this PR (release prep only)
- Version → `1.7.1` in `pyproject.toml` + `src/librarian/version.py` (kept in sync per the metadata-consistency test and the release tag check).
- `CHANGELOG.md`: `## Unreleased` → `## 1.7.1 - 2026-06-26` (satisfies the changelog-ready gate).
- README stable-version line + wheel example, the `test_release_workflow` assertion, and the DEPLOYMENT image example → `1.7.1`.

Verified locally: changelog gate passes for `v1.7.1`, version/release-doc tests pass, full suite **569 passed / 3 skipped**, ruff clean.

**After merge**, push the `v1.7.1` tag to trigger the release pipeline (wheel + both DMGs + Docker + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_