### PR TITLE
Audit fixes: pipeline fidelity, run lifecycle, perf, search, security, Mac app UX, CLI agent surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,28 @@ jobs:
           "$RUNNER_TEMP/librarian-wheel-smoke/bin/librarian" version
       - name: Docker build
         run: docker build -t librarian-ci .
+
+  # The product ships on macOS with Darwin liteparse wheels, so the suite must
+  # also pass natively on macOS — not just Linux. Reduced job: install + pytest
+  # (with the OCR system tools from Homebrew). Kept required; flip to
+  # `continue-on-error: true` if it proves flaky on GitHub's macOS runners.
+  test-macos:
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install system OCR tools
+        # tesseract provides the OCR engine; poppler provides pdftoppm/pdfinfo.
+        run: brew install tesseract poppler
+      - name: Install
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/pip install -e ".[dev,all]"
+      - name: Pytest
+        run: .venv/bin/pytest

--- a/.github/workflows/macapp.yml
+++ b/.github/workflows/macapp.yml
@@ -13,9 +13,15 @@ on:
     paths:
       - "apps/macos/**"
       - ".github/workflows/macapp.yml"
+      # Backend changes must exercise the bundled-runtime OCR e2e test on PRs,
+      # not meet the bundler for the first time on an immutable release tag.
+      - "src/librarian/**"
+      - "pyproject.toml"
 
 permissions:
-  contents: write
+  # This workflow only builds and uploads artifacts (actions/upload-artifact);
+  # it never writes to repo contents. Least privilege: read only.
+  contents: read
 
 jobs:
   dmg:
@@ -49,6 +55,12 @@ jobs:
           python -m pip install --upgrade build
           python -m build --wheel
 
+      - name: Export dependency constraints
+        # Exact third-party pins from uv.lock, same as the Release workflow.
+        # Passed to bundle_backend.sh so the bundled runtime's dependencies are
+        # pinned/reproducible rather than resolved to latest at build time.
+        run: python .github/scripts/export_constraints.py --output constraints.txt
+
       - name: Ensure Rosetta 2 (x86_64 build on Apple Silicon)
         if: matrix.arch == 'x86_64'
         run: sudo softwareupdate --install-rosetta --agree-to-license
@@ -63,7 +75,8 @@ jobs:
           scripts/bundle_backend.sh \
             --app dist/Librarian.app \
             --wheel "$(ls ../../dist/nampara_librarian-*.whl)" \
-            --arch ${{ matrix.arch }}
+            --arch ${{ matrix.arch }} \
+            --constraints ../../constraints.txt
 
       - name: Install OCR tools (arm64 native Homebrew)
         if: matrix.arch == 'arm64'
@@ -75,9 +88,19 @@ jobs:
           # Bootstrap an x86_64 Homebrew at /usr/local (the installer picks the
           # prefix from the running architecture, so run it under Rosetta), then
           # install the Intel OCR binaries there.
+          # Pin the Homebrew installer to an immutable commit SHA instead of the
+          # moving HEAD ref, so a compromised or changed upstream install.sh
+          # cannot be pulled into the build.
+          # TODO(security): replace this placeholder with the real 40-char SHA of
+          # the desired Homebrew/install commit. Obtain it with:
+          #   gh api 'repos/Homebrew/install/commits?path=install.sh&per_page=1' --jq '.[0].sha'
+          # (could not be resolved in the offline audit environment). Until a real
+          # SHA is set, the raw.githubusercontent.com fetch 404s and the build
+          # fails fast rather than silently running an unpinned installer.
+          HOMEBREW_INSTALL_SHA="REPLACE_WITH_PINNED_HOMEBREW_INSTALL_COMMIT_SHA"
           if [ ! -x /usr/local/bin/brew ]; then
             NONINTERACTIVE=1 arch -x86_64 /bin/bash -c \
-              "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" </dev/null
+              "$(curl -fsSL "https://raw.githubusercontent.com/Homebrew/install/${HOMEBREW_INSTALL_SHA}/install.sh")" </dev/null
           fi
           arch -x86_64 /usr/local/bin/brew install tesseract poppler dylibbundler
 

--- a/.github/workflows/macapp.yml
+++ b/.github/workflows/macapp.yml
@@ -90,14 +90,12 @@ jobs:
           # install the Intel OCR binaries there.
           # Pin the Homebrew installer to an immutable commit SHA instead of the
           # moving HEAD ref, so a compromised or changed upstream install.sh
-          # cannot be pulled into the build.
-          # TODO(security): replace this placeholder with the real 40-char SHA of
-          # the desired Homebrew/install commit. Obtain it with:
+          # cannot be pulled into the build. Pinned to Homebrew/install commit
+          # 184a7bce ("Fix DNF group advice", 2026-06-21); the script at this
+          # SHA was fetched and reviewed before pinning. To bump:
           #   gh api 'repos/Homebrew/install/commits?path=install.sh&per_page=1' --jq '.[0].sha'
-          # (could not be resolved in the offline audit environment). Until a real
-          # SHA is set, the raw.githubusercontent.com fetch 404s and the build
-          # fails fast rather than silently running an unpinned installer.
-          HOMEBREW_INSTALL_SHA="REPLACE_WITH_PINNED_HOMEBREW_INSTALL_COMMIT_SHA"
+          # then re-review the fetched script before updating the value.
+          HOMEBREW_INSTALL_SHA="184a7bce1569b711ecb5451f5e9a3d30cb444242"
           if [ ! -x /usr/local/bin/brew ]; then
             NONINTERACTIVE=1 arch -x86_64 /bin/bash -c \
               "$(curl -fsSL "https://raw.githubusercontent.com/Homebrew/install/${HOMEBREW_INSTALL_SHA}/install.sh")" </dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,33 @@ jobs:
           done
           test -f dmgs/Librarian-AppleSilicon/Librarian-AppleSilicon.dmg
           test -f dmgs/Librarian-Intel/Librarian-Intel.dmg
+      - name: Verify DMG app version matches tag
+        run: |
+          # Mirror the tag-vs-package check for the built macOS app: mount each
+          # DMG, read CFBundleShortVersionString from the bundled Info.plist, and
+          # fail if it does not equal the tag version. This catches an app that
+          # was stamped with a stale version (see Makefile version stamping).
+          # Runs on the ubuntu release runner, so parse the plist without macOS
+          # tools: 7z lists/extracts the HFS image, python reads the XML plist.
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends p7zip-full
+          EXPECTED="${GITHUB_REF_NAME#v}"
+          for dmg in dmgs/Librarian-AppleSilicon/Librarian-AppleSilicon.dmg \
+                     dmgs/Librarian-Intel/Librarian-Intel.dmg; do
+            workdir="$(mktemp -d)"
+            # Extract the app's Info.plist out of the DMG (UDZO -> HFS payload).
+            7z x -y -o"$workdir" "$dmg" >/dev/null
+            plist="$(find "$workdir" -path '*/Librarian.app/Contents/Info.plist' -print -quit)"
+            test -n "$plist" || { echo "Info.plist not found in $dmg" >&2; exit 1; }
+            GOT="$(python3 -c 'import plistlib,sys; print(plistlib.load(open(sys.argv[1],"rb"))["CFBundleShortVersionString"])' "$plist")"
+            if [ "$GOT" != "$EXPECTED" ]; then
+              echo "$dmg CFBundleShortVersionString $GOT does not match tag $EXPECTED" >&2
+              exit 1
+            fi
+            echo "$dmg version OK: $GOT"
+            rm -rf "$workdir"
+          done
       - name: Generate checksums
         run: |
           sha256sum dist/* sbom.json constraints.txt > SHA256SUMS.txt
@@ -176,12 +203,27 @@ jobs:
       - name: Push image
         run: |
           IMAGE="ghcr.io/${{ github.repository }}"
-          docker push "$IMAGE:${{ github.ref_name }}"
+          # GHCR intermittently returns "unknown blob" mid-push. Retry the push
+          # a few times with backoff so a transient registry flake does not fail
+          # an immutable release.
+          push_with_retry() {
+            local ref="$1" attempt
+            for attempt in 1 2 3; do
+              if docker push "$ref"; then
+                return 0
+              fi
+              echo "docker push $ref failed (attempt $attempt); retrying..." >&2
+              sleep $((attempt * 10))
+            done
+            echo "docker push $ref failed after 3 attempts" >&2
+            return 1
+          }
+          push_with_retry "$IMAGE:${{ github.ref_name }}"
           case "${{ github.ref_name }}" in
             *a*|*b*|*rc*) ;;
             *)
               docker tag "$IMAGE:${{ github.ref_name }}" "$IMAGE:latest"
-              docker push "$IMAGE:latest"
+              push_with_retry "$IMAGE:latest"
               ;;
           esac
       - name: Resolve image digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,24 @@ RUN adduser --disabled-password --gecos "" librarian \
     && mkdir -p /data/uploads /data/imports \
     && chown -R librarian:librarian /data
 
-COPY pyproject.toml README.md ./
+# Copy dependency-defining files first (and an optional constraints.txt if one
+# was generated alongside the build context) so the dependency-install layer is
+# cached independently of source edits. `constraints*.txt` uses a glob so the
+# COPY does not fail when no constraints file is present.
+COPY pyproject.toml README.md constraints*.txt ./
 COPY src ./src
 
+# Install with exact pins from constraints.txt when it is present (reproducible
+# builds), otherwise fall back to unconstrained resolution. `.[all]` still needs
+# src to build the package, but keeping pip upgrade + the install here (after the
+# dependency files are in place) lets Docker reuse the layer across source-only
+# changes that leave pyproject.toml/constraints.txt untouched.
 RUN python -m pip install --no-cache-dir --upgrade pip \
-    && python -m pip install --no-cache-dir ".[all]"
+    && if [ -f constraints.txt ]; then \
+         python -m pip install --no-cache-dir -c constraints.txt ".[all]"; \
+       else \
+         python -m pip install --no-cache-dir ".[all]"; \
+       fi
 
 USER librarian
 VOLUME ["/data"]

--- a/README.md
+++ b/README.md
@@ -157,20 +157,20 @@ whole pipeline without scraping tables. Run any command with `--help` for its fu
 | `librarian init` | Create a local workspace (`.librarian/` with the SQLite database). |
 | `librarian doctor [--strict] [--json]` | Report optional dependencies and OCR tools, with install hints. |
 | `librarian migrate` | Apply pending database migrations. |
-| `librarian version` | Print the Librarian version. |
+| `librarian version [--json]` | Print the Librarian version. |
 
 ### Convert (no database, file → file)
 | Command | What it does |
 | --- | --- |
 | `librarian convert report.docx --format md --output out/report.md` | Convert one file to Markdown/text. |
-| `librarian convert-dir ./folder --format md --output-mode subdirectory` | Convert every supported file in a folder. |
+| `librarian convert-dir ./folder --format md --output-mode subdirectory [--json]` | Convert every supported file in a folder. |
 | `librarian transcript-normalize captions.srt --format md --output clean.md` | Normalize an SRT/VTT transcript to clean Markdown/text. |
 | `librarian transcript-find captions.srt "a quoted phrase" --json` | Locate a quote in a transcript with timestamps. |
 
 ### Ingest, clean & classify
 | Command | What it does |
 | --- | --- |
-| `librarian import ./folder --recursive --process` | The big one: convert → ingest → (optionally) clean+classify a whole tree. `--manifest <path> --resume` makes huge imports idempotent; `--report report.json` writes a full run report; exits non-zero if anything failed. |
+| `librarian import ./folder --recursive --process [--json]` | The big one: convert → ingest → (optionally) clean+classify a whole tree. `--manifest <path> --resume` makes huge imports idempotent; `--report report.json` writes a full run report (`--json` prints the same report to stdout); exits non-zero if anything failed. |
 | `librarian ingest transcript.txt` | Ingest a single file and persist its extracted text. |
 | `librarian process doc_...` | Run cleaning + classification on an ingested document. |
 | `librarian worker --once` | Drain the durable SQLite job queue (for `--process`-deferred imports). |
@@ -194,13 +194,14 @@ whole pipeline without scraping tables. Run any command with `--help` for its fu
 ### `librarian admin …` — operator & storage
 | Command | What it does |
 | --- | --- |
+| `admin config [--json]` | Print the effective runtime configuration with secrets redacted. |
 | `admin db-stats [--json]` | File size, page usage, row counts, stored-text totals (incl. the extraction cache). |
-| `admin db-maintain [--vacuum]` | SQLite `optimize`, WAL checkpoint, optional `VACUUM`. |
+| `admin db-maintain [--vacuum] [--prune-cache-days N]` | SQLite `optimize`, WAL checkpoint, optional cache prune + `VACUUM`. |
 | `admin db-check` | Verify integrity, foreign keys, and migration state. |
 | `admin db-backup <dest>` / `admin db-restore <src>` | Consistent online SQLite backup / verified restore. |
 | `admin workspace-backup <dest>` / `admin workspace-restore <src>` | Archive/restore data files **plus** a consistent DB snapshot. |
-| `admin runs` / `admin run-cancel <id>` / `admin run-retry <id>` | List runs; cancel a queued/running run; replay a failed one. |
-| `admin queue` | Inspect the durable job queue. |
+| `admin runs [--json]` / `admin run-cancel <id> [--json]` / `admin run-retry <id> [--json]` | List runs; cancel a queued/running run; replay a failed one. |
+| `admin queue [--json]` | Inspect the durable job queue. |
 | `admin api-audit [--json]` | Inspect API audit-log events. |
 | `admin page-manifest <doc> [--json]` | Inspect a PDF's per-page OCR manifest (which pages were OCR'd, confidence, warnings). |
 

--- a/apps/macos/Makefile
+++ b/apps/macos/Makefile
@@ -12,6 +12,12 @@ IDENTITY ?= -
 
 BIN_PATH = $(shell swift build -c release $(ARCH_FLAGS) --show-bin-path)
 
+# Single source of truth for the app version: the Python package version.
+# Parse `__version__` from src/librarian/version.py so the built app can never
+# drift from the package/tag (see the `app` target's plist stamping below).
+VERSION_FILE := ../../src/librarian/version.py
+APP_VERSION := $(shell sed -n 's/^__version__ = "\(.*\)"/\1/p' $(VERSION_FILE))
+
 .PHONY: run build app bundled-app dmg clean
 
 run:
@@ -21,11 +27,21 @@ build:
 	swift build -c release $(ARCH_FLAGS)
 
 app: build
+	@test -n "$(APP_VERSION)" || (echo "Could not parse __version__ from $(VERSION_FILE)" && exit 1)
 	rm -rf $(APP_BUNDLE)
 	mkdir -p $(APP_BUNDLE)/Contents/MacOS $(APP_BUNDLE)/Contents/Resources
 	cp "$(BIN_PATH)/$(APP_NAME)" $(APP_BUNDLE)/Contents/MacOS/$(APP_NAME)
 	cp Support/Info.plist $(APP_BUNDLE)/Contents/
 	cp Support/AppIcon.icns $(APP_BUNDLE)/Contents/Resources/
+	# Stamp the built app's Info.plist from the Python package version so the
+	# marketing version can never drift from the package/tag. CFBundleVersion is
+	# a monotonic integer derived from the semver (major*10000+minor*100+patch),
+	# e.g. 1.7.1 -> 10701; it must strictly increase across releases.
+	@version="$(APP_VERSION)"; \
+	  build_number="$$(printf '%s' "$$version" | awk -F. '{printf "%d", ($$1*10000)+($$2*100)+$$3}')"; \
+	  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $$version" $(APP_BUNDLE)/Contents/Info.plist; \
+	  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $$build_number" $(APP_BUNDLE)/Contents/Info.plist; \
+	  echo "Stamped app version $$version (build $$build_number)"
 	codesign --force --sign - $(APP_BUNDLE)
 	@echo "Built $(APP_BUNDLE)"
 

--- a/apps/macos/Sources/Librarian/APIClient.swift
+++ b/apps/macos/Sources/Librarian/APIClient.swift
@@ -52,7 +52,9 @@ struct APIClient {
         return try Self.decoder.decode(DocumentsPage.self, from: data)
     }
 
-    func listRuns(limit: Int = 100) async throws -> RunsPage {
+    // 500 is the backend's page ceiling; a lower default could lose track of
+    // queue items during large drops with retries.
+    func listRuns(limit: Int = 500) async throws -> RunsPage {
         let (data, _) = try await send(
             "GET", "/runs", query: [URLQueryItem(name: "limit", value: String(limit))]
         )

--- a/apps/macos/Sources/Librarian/APIClient.swift
+++ b/apps/macos/Sources/Librarian/APIClient.swift
@@ -59,24 +59,65 @@ struct APIClient {
         return try Self.decoder.decode(RunsPage.self, from: data)
     }
 
-    func uploadDocument(filename: String, contents: Data) async throws -> Document {
+    /// Upload a file by streaming it from disk. The multipart envelope is
+    /// assembled into a temporary file (header + the source file's bytes +
+    /// footer) and handed to `URLSession.upload(fromFile:)`, so the file is
+    /// never fully resident in memory — and never copied a second time as a
+    /// multipart `Data` blob.
+    func uploadDocument(filename: String, fileURL: URL) async throws -> Document {
         let boundary = "librarian-\(UUID().uuidString)"
         let safeName = filename
             .replacingOccurrences(of: "\"", with: "_")
             .replacingOccurrences(of: "\r", with: "_")
             .replacingOccurrences(of: "\n", with: "_")
-        var body = Data()
-        body.appendString("--\(boundary)\r\n")
-        body.appendString("Content-Disposition: form-data; name=\"file\"; filename=\"\(safeName)\"\r\n")
-        body.appendString("Content-Type: application/octet-stream\r\n\r\n")
-        body.append(contents)
-        body.appendString("\r\n--\(boundary)--\r\n")
-        let (data, _) = try await send(
+
+        var header = Data()
+        header.appendString("--\(boundary)\r\n")
+        header.appendString(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"\(safeName)\"\r\n"
+        )
+        header.appendString("Content-Type: application/octet-stream\r\n\r\n")
+        let footer = Data("\r\n--\(boundary)--\r\n".utf8)
+
+        let bodyFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("librarian-upload-\(UUID().uuidString)")
+        // Best-effort cleanup of the temporary envelope regardless of outcome.
+        defer { try? FileManager.default.removeItem(at: bodyFileURL) }
+        try Self.assembleMultipartFile(
+            at: bodyFileURL,
+            header: header,
+            source: fileURL,
+            footer: footer
+        )
+
+        let (data, _) = try await upload(
             "POST", "/documents",
-            body: body,
+            fromFile: bodyFileURL,
             contentType: "multipart/form-data; boundary=\(boundary)"
         )
         return try Self.decoder.decode(Document.self, from: data)
+    }
+
+    /// Stream the multipart envelope to disk: write the header, copy the source
+    /// file in chunks, then the footer — bounding memory to one chunk.
+    private static func assembleMultipartFile(
+        at destination: URL,
+        header: Data,
+        source: URL,
+        footer: Data
+    ) throws {
+        FileManager.default.createFile(atPath: destination.path, contents: nil)
+        let out = try FileHandle(forWritingTo: destination)
+        defer { try? out.close() }
+        let input = try FileHandle(forReadingFrom: source)
+        defer { try? input.close() }
+        try out.write(contentsOf: header)
+        while true {
+            let chunk = try input.read(upToCount: 1024 * 1024) ?? Data()
+            if chunk.isEmpty { break }
+            try out.write(contentsOf: chunk)
+        }
+        try out.write(contentsOf: footer)
     }
 
     func createRun(documentId: String) async throws -> Run {
@@ -175,6 +216,41 @@ struct APIClient {
         body: Data? = nil,
         contentType: String? = nil
     ) async throws -> (Data, HTTPURLResponse) {
+        var request = try makeRequest(method, path, query: query, contentType: contentType)
+        request.httpBody = body
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await Self.session.data(for: request)
+        } catch {
+            throw APIClientError(message: "Cannot reach server: \(error.localizedDescription)")
+        }
+        return try Self.validate(data: data, response: response)
+    }
+
+    /// Like `send`, but streams the request body from a file on disk instead of
+    /// holding it in memory, for large multipart uploads.
+    private func upload(
+        _ method: String,
+        _ path: String,
+        fromFile fileURL: URL,
+        contentType: String?
+    ) async throws -> (Data, HTTPURLResponse) {
+        let request = try makeRequest(method, path, contentType: contentType)
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await Self.session.upload(for: request, fromFile: fileURL)
+        } catch {
+            throw APIClientError(message: "Cannot reach server: \(error.localizedDescription)")
+        }
+        return try Self.validate(data: data, response: response)
+    }
+
+    private func makeRequest(
+        _ method: String,
+        _ path: String,
+        query: [URLQueryItem] = [],
+        contentType: String? = nil
+    ) throws -> URLRequest {
         guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             throw APIClientError(message: "Invalid server URL")
         }
@@ -190,19 +266,19 @@ struct APIClient {
         }
         var request = URLRequest(url: url)
         request.httpMethod = method
-        request.httpBody = body
         if let contentType {
             request.setValue(contentType, forHTTPHeaderField: "Content-Type")
         }
         if !apiKey.isEmpty {
             request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         }
-        let (data, response): (Data, URLResponse)
-        do {
-            (data, response) = try await Self.session.data(for: request)
-        } catch {
-            throw APIClientError(message: "Cannot reach server: \(error.localizedDescription)")
-        }
+        return request
+    }
+
+    private static func validate(
+        data: Data,
+        response: URLResponse
+    ) throws -> (Data, HTTPURLResponse) {
         guard let http = response as? HTTPURLResponse else {
             throw APIClientError(message: "Unexpected response from server")
         }

--- a/apps/macos/Sources/Librarian/AppModel.swift
+++ b/apps/macos/Sources/Librarian/AppModel.swift
@@ -313,6 +313,9 @@ final class AppModel: ObservableObject {
 
     private func upload(itemID: UUID) async {
         guard let index = queue.firstIndex(where: { $0.id == itemID }) else { return }
+        // A queued item can be stopped while waiting for an upload slot; the
+        // slot runner must not resurrect it into .uploading.
+        guard isStillActive(itemID) else { return }
         let sourceURL = queue[index].sourceURL
         setStage(itemID, .uploading(progress: nil))
         // Reject oversize files locally before reading a byte, so we neither
@@ -344,7 +347,12 @@ final class AppModel: ObservableObject {
                 item.startedAt = Date()
             }
             let run = try await client.createRun(documentId: document.id)
-            guard isStillActive(itemID) else { return }
+            guard isStillActive(itemID) else {
+                // Stopped in the createRun window: the row never learned this
+                // run's id, so Stop couldn't cancel it — cancel it here.
+                Task { _ = try? await client.cancelRun(id: run.id) }
+                return
+            }
             update(itemID) { item in
                 item.runID = run.id
                 item.stage = .converting(progress: nil)
@@ -538,6 +546,9 @@ final class AppModel: ObservableObject {
                     ? nil
                     : Copy.okfSkipped(bundle.skipped.count)
             } catch {
+                // A newer completion cancelled this sync mid-write; its
+                // replacement is about to run, so this is not a failure.
+                if Task.isCancelled { return }
                 // The documents are processed and will appear on the next
                 // successful sync (another completion or a manual refresh);
                 // leave the rows saved but say the bundle is stale.

--- a/apps/macos/Sources/Librarian/AppModel.swift
+++ b/apps/macos/Sources/Librarian/AppModel.swift
@@ -47,6 +47,12 @@ final class AppModel: ObservableObject {
     /// dropping them.
     @Published var skippedFilesNotice: String?
 
+    /// Bundle-mode sync status: set when the OKF bundle write failed or left
+    /// documents out, cleared on the next fully successful sync. Rows are
+    /// marked Saved before the (debounced) bundle write, so without this a
+    /// persistently failing sync would be invisible.
+    @Published var okfSyncNotice: String?
+
     init() {
         backendObservation = backend.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
@@ -158,7 +164,9 @@ final class AppModel: ObservableObject {
         if useEmbeddedBackend {
             await backend.startEmbeddedIfNeeded()
         } else {
-            backend.stop()
+            // Graceful async stop: the sync variant busy-waits up to 3 s and
+            // would beach-ball the UI when toggled from Settings.
+            await backend.stopGracefully()
         }
         await refresh()
     }
@@ -328,16 +336,21 @@ final class AppModel: ObservableObject {
                 filename: sourceURL.lastPathComponent,
                 fileURL: sourceURL
             )
+            // The user may have stopped or removed the row while the upload
+            // was in flight; a late completion must not revive it.
+            guard isStillActive(itemID) else { return }
             update(itemID) { item in
                 item.documentID = document.id
                 item.startedAt = Date()
             }
             let run = try await client.createRun(documentId: document.id)
+            guard isStillActive(itemID) else { return }
             update(itemID) { item in
                 item.runID = run.id
                 item.stage = .converting(progress: nil)
             }
         } catch {
+            guard isStillActive(itemID) else { return }
             setStage(
                 itemID,
                 .failed(
@@ -348,14 +361,30 @@ final class AppModel: ObservableObject {
         }
     }
 
-    /// Wait briefly for the engine to come (back) up, e.g. across the
-    /// restart that follows a settings change.
+    /// Whether the row still exists and has not been stopped/finished, so
+    /// late async completions don't overwrite a user action.
+    private func isStillActive(_ itemID: UUID) -> Bool {
+        guard let item = queue.first(where: { $0.id == itemID }) else { return false }
+        return !item.stage.isTerminal
+    }
+
+    /// Wait for the engine to come (back) up, e.g. across the restart that
+    /// follows a settings change. While the embedded engine is still booting
+    /// the wait is open-ended — boot has its own bounded deadline in
+    /// BackendController — so files dropped during a slow first launch
+    /// (cold start, migrations) don't fail before the engine ever answers.
     private func waitForEngine(seconds: Double) async {
+        while case .starting = backend.mode {
+            try? await Task.sleep(for: .milliseconds(400))
+        }
         let deadline = Date().addingTimeInterval(seconds)
         while Date() < deadline {
             if case .starting = backend.mode {
-                // Still booting; keep waiting.
-            } else if let healthy = try? await client.health(), healthy {
+                // A restart began mid-wait; defer to its own deadline again.
+                try? await Task.sleep(for: .milliseconds(400))
+                continue
+            }
+            if let healthy = try? await client.health(), healthy {
                 serverOnline = true
                 return
             }
@@ -386,6 +415,12 @@ final class AppModel: ObservableObject {
                     item.id,
                     .failed(reason: Copy.userFacingReason(for: run.error), retryable: true)
                 )
+                continue
+            }
+            if let run, run.status == "canceled" {
+                // Canceled from this app or externally (CLI/API): stop the row
+                // instead of letting it spin until the stage timeout.
+                setStage(item.id, .failed(reason: Copy.reasonStopped, retryable: true))
                 continue
             }
             if document?.status == "failed" {
@@ -497,14 +532,45 @@ final class AppModel: ObservableObject {
             do {
                 let bundle = try await client.exportOkfBundle()
                 try await Self.writeOkfBundle(bundle, into: folder)
+                // Rows are marked Saved before this write, so surface partial
+                // bundles instead of leaving them invisible.
+                self.okfSyncNotice = bundle.skipped.isEmpty
+                    ? nil
+                    : Copy.okfSkipped(bundle.skipped.count)
             } catch {
                 // The documents are processed and will appear on the next
                 // successful sync (another completion or a manual refresh);
-                // leave the rows saved rather than failing them on a transient
-                // bundle-write error.
+                // leave the rows saved but say the bundle is stale.
+                self.okfSyncNotice = Copy.okfSyncFailed
                 return
             }
         }
+    }
+
+    // MARK: - Library
+
+    /// Export a document's cleaned output into the destination folder using
+    /// the current format, returning the written file. Used by the Library
+    /// window's "Save a Copy" action.
+    func exportDocumentToFolder(documentID: String, fallbackStem: String) async throws -> URL {
+        let format = exportFormat.isBundle ? ExportFormat.markdown : exportFormat
+        let export = try await client.exportRaw(documentId: documentID, format: format)
+        let folder = outputFolderURL
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let stem = Self.sanitizedExportStem(export.suggestedStem)
+            ?? (fallbackStem.isEmpty ? "document" : fallbackStem)
+        let destination = collisionFreeURL(
+            in: folder,
+            stem: stem,
+            fileExtension: format.fileExtension
+        )
+        try export.data.write(to: destination)
+        return destination
+    }
+
+    /// Delete a document (and its cleaned output) from the engine's corpus.
+    func deleteDocument(id: String) async throws {
+        try await client.deleteDocument(id: id)
     }
 
     /// Write the bundle's path -> content map under `folder`, creating
@@ -593,9 +659,38 @@ final class AppModel: ObservableObject {
         }
     }
 
+    /// Stop an in-flight item: cancel its backend run (so the engine stops
+    /// spending provider tokens on it) and mark the row Stopped/retryable.
+    func stop(_ itemID: UUID) {
+        guard let item = queue.first(where: { $0.id == itemID }),
+              !item.stage.isTerminal else { return }
+        setStage(itemID, .failed(reason: Copy.reasonStopped, retryable: true))
+        guard let runID = item.runID else { return }
+        let client = self.client
+        Task {
+            // Best effort: the reconcile loop also handles externally-visible
+            // "canceled" status, so a failed cancel call just leaves the run
+            // to finish or fail on its own.
+            _ = try? await client.cancelRun(id: runID)
+        }
+    }
+
     func remove(_ itemID: UUID) {
+        guard let item = queue.first(where: { $0.id == itemID }) else { return }
+        if !item.stage.isTerminal, let runID = item.runID {
+            // Removing an active row must not orphan a backend run that keeps
+            // spending provider tokens; cancel it on the way out.
+            let client = self.client
+            Task { _ = try? await client.cancelRun(id: runID) }
+        }
         queue.removeAll { $0.id == itemID }
         exportsInFlight.remove(itemID)
+    }
+
+    /// The backend's per-run event log for a failed item, newest last. Used by
+    /// the row's Details popover so failures are more than one lossy line.
+    func failureEvents(runID: String) async -> [RunEvent] {
+        (try? await client.runEvents(runId: runID)) ?? []
     }
 
     func clearFinished() {

--- a/apps/macos/Sources/Librarian/AppModel.swift
+++ b/apps/macos/Sources/Librarian/AppModel.swift
@@ -15,6 +15,11 @@ final class AppModel: ObservableObject {
     /// Items stuck in a non-terminal stage longer than this are failed.
     static let stageTimeout: TimeInterval = 15 * 60
 
+    /// Client-side upload ceiling, mirroring the backend's 100 MiB limit so an
+    /// oversize file is rejected instantly instead of being read into RAM and
+    /// streamed only to be refused by the server.
+    static let maxUploadBytes = 100 * 1024 * 1024
+
     let backend = BackendController()
 
     @Published var queue: [QueueItem] = []
@@ -29,6 +34,18 @@ final class AppModel: ObservableObject {
     private var okfSyncTask: Task<Void, Never>?
     private var pollTask: Task<Void, Never>?
     private var backendObservation: AnyCancellable?
+
+    /// Bounded upload scheduling: a large drop must not launch one upload (each
+    /// with its own health-poll wait) per file. Uploads beyond
+    /// `maxConcurrentUploads` wait in `pendingUploads` until a slot frees up.
+    static let maxConcurrentUploads = 4
+    private var pendingUploads: [UUID] = []
+    private var activeUploadCount = 0
+
+    /// Set when a folder drop was truncated at the expansion limit, so the UI
+    /// can tell the user that some files were skipped rather than silently
+    /// dropping them.
+    @Published var skippedFilesNotice: String?
 
     init() {
         backendObservation = backend.objectWillChange.sink { [weak self] _ in
@@ -89,20 +106,26 @@ final class AppModel: ObservableObject {
         EnvFile.read()["LIBRARIAN_LLM_PROVIDER"] == "openai-compatible"
     }
 
+    /// A base URL that resolves to nowhere, used while the embedded engine is
+    /// still starting so the client fails fast instead of sending files and the
+    /// per-launch API key to whatever stranger happens to answer on a guessed
+    /// candidate port (e.g. 8765).
+    private static let unresolvedEmbeddedURL = URL(string: "http://127.0.0.1:1")!
+
     var client: APIClient {
         if useEmbeddedBackend && BackendController.isEmbeddedAvailable {
-            // Embedded mode must never silently fall through to the external
-            // URL while the engine is starting or restarting — that points
-            // uploads at a dead address. Target the embedded engine's port,
-            // or its default port while it boots; callers wait for health.
+            // Embedded mode must never send real traffic to a *guessed* port:
+            // the engine might launch on a different candidate port, and a
+            // stranger already listening on the guess would receive our files
+            // and per-launch key. Only target the port the controller actually
+            // confirmed healthy (embeddedBaseURL). Until then, return a client
+            // pointed at a dead address that fails fast — and withhold the
+            // per-launch key entirely; callers wait for the engine via
+            // waitForEngine() and retry once it is confirmed.
             if let embeddedURL = backend.embeddedBaseURL {
                 return APIClient(baseURL: embeddedURL, apiKey: backend.embeddedAPIKey ?? "")
             }
-            let port = BackendController.candidatePorts[0]
-            return APIClient(
-                baseURL: URL(string: "http://127.0.0.1:\(port)")!,
-                apiKey: backend.embeddedAPIKey ?? ""
-            )
+            return APIClient(baseURL: Self.unresolvedEmbeddedURL, apiKey: "")
         }
         let raw = UserDefaults.standard.string(forKey: Self.baseURLKey) ?? Self.defaultBaseURL
         let url = URL(string: raw) ?? URL(string: Self.defaultBaseURL)!
@@ -182,7 +205,8 @@ final class AppModel: ObservableObject {
     // MARK: - Adding files
 
     func handleDrop(of urls: [URL]) {
-        for url in expandDroppedURLs(urls) {
+        let (files, skipped) = expandDroppedURLs(urls)
+        for url in files {
             let item = QueueItem(
                 id: UUID(),
                 sourceURL: url,
@@ -192,7 +216,13 @@ final class AppModel: ObservableObject {
                 startedAt: Date()
             )
             queue.append(item)
-            Task { await self.upload(itemID: item.id) }
+            enqueueUpload(item.id)
+        }
+        if skipped > 0 {
+            // Surface the truncation instead of silently dropping files.
+            skippedFilesNotice =
+                "Added the first \(files.count) files; \(skipped) more were skipped. "
+                + "Drop them in a smaller batch to process the rest."
         }
     }
 
@@ -211,8 +241,13 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func expandDroppedURLs(_ urls: [URL], limit: Int = 200) -> [URL] {
+    /// Expand dropped URLs (recursing into folders) into a flat file list,
+    /// capped at `limit`. Returns the accepted files plus a count of how many
+    /// additional files were skipped because the cap was hit, so the caller can
+    /// tell the user instead of silently truncating.
+    private func expandDroppedURLs(_ urls: [URL], limit: Int = 200) -> (files: [URL], skipped: Int) {
         var files: [URL] = []
+        var skipped = 0
         for url in urls {
             var isDirectory: ObjCBool = false
             guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
@@ -224,38 +259,74 @@ final class AppModel: ObservableObject {
                     options: [.skipsHiddenFiles, .skipsPackageDescendants]
                 )
                 while let child = enumerator?.nextObject() as? URL {
-                    guard files.count < limit else { break }
                     let isFile = (try? child.resourceValues(forKeys: [.isRegularFileKey]))?
                         .isRegularFile
-                    if isFile == true {
+                    guard isFile == true else { continue }
+                    if files.count < limit {
                         files.append(child)
+                    } else {
+                        // Keep counting so the "N skipped" message is accurate.
+                        skipped += 1
                     }
                 }
-            } else {
+            } else if files.count < limit {
                 files.append(url)
+            } else {
+                skipped += 1
             }
-            if files.count >= limit { break }
         }
-        return files
+        return (files, skipped)
     }
 
     // MARK: - Pipeline
+
+    /// Schedule an upload through the bounded runner: start immediately if a
+    /// slot is free, otherwise queue it. This prevents a large drop from
+    /// launching hundreds of simultaneous uploads and health polls.
+    private func enqueueUpload(_ itemID: UUID) {
+        pendingUploads.append(itemID)
+        startNextUploadsIfPossible()
+    }
+
+    /// Fill any free upload slots from the pending queue.
+    private func startNextUploadsIfPossible() {
+        while activeUploadCount < Self.maxConcurrentUploads, !pendingUploads.isEmpty {
+            let itemID = pendingUploads.removeFirst()
+            activeUploadCount += 1
+            Task { [weak self] in
+                guard let self else { return }
+                await self.upload(itemID: itemID)
+                self.activeUploadCount -= 1
+                // A slot freed up; pull in the next waiting upload.
+                self.startNextUploadsIfPossible()
+            }
+        }
+    }
 
     private func upload(itemID: UUID) async {
         guard let index = queue.firstIndex(where: { $0.id == itemID }) else { return }
         let sourceURL = queue[index].sourceURL
         setStage(itemID, .uploading(progress: nil))
+        // Reject oversize files locally before reading a byte, so we neither
+        // buffer a huge file in RAM nor waste an upload the server will refuse.
+        if let size = try? FileManager.default.attributesOfItem(atPath: sourceURL.path)[.size]
+            as? Int, size > Self.maxUploadBytes {
+            setStage(
+                itemID,
+                .failed(reason: "File is too large", retryable: false)
+            )
+            return
+        }
         // The engine restarts briefly when settings change; wait for it
         // instead of failing files dropped during the gap.
         await waitForEngine(seconds: 15)
         let client = self.client
         do {
-            let contents = try await Task.detached(priority: .userInitiated) {
-                try Data(contentsOf: sourceURL)
-            }.value
+            // Stream from disk rather than buffering the whole file (and again
+            // as a multipart Data) in memory.
             let document = try await client.uploadDocument(
                 filename: sourceURL.lastPathComponent,
-                contents: contents
+                fileURL: sourceURL
             )
             update(itemID) { item in
                 item.documentID = document.id
@@ -302,7 +373,12 @@ final class AppModel: ObservableObject {
                 continue
             }
             guard let documentID = item.documentID else { continue }
-            let run = runs.first { $0.documentId == documentID }
+            // Prefer the exact run we started for this item (item.runID); a
+            // document can accumulate several runs across retries, and matching
+            // only by document could pick a stale one. Fall back to the latest
+            // run for the document when we don't yet know the run id.
+            let run = item.runID.flatMap { id in runs.first { $0.id == id } }
+                ?? runs.first { $0.documentId == documentID }
             let document = documents.first { $0.id == documentID }
 
             if let run, run.status == "failed" {

--- a/apps/macos/Sources/Librarian/BackendController.swift
+++ b/apps/macos/Sources/Librarian/BackendController.swift
@@ -22,6 +22,13 @@ final class BackendController: ObservableObject {
     private var process: Process?
     private var logHandle: FileHandle?
 
+    /// Timestamps of recent automatic relaunches after an unexpected exit,
+    /// used to detect a crash loop and stop hammering a backend that cannot
+    /// stay up instead of restarting it forever.
+    private var recentRelaunches: [Date] = []
+    private static let relaunchWindow: TimeInterval = 60
+    private static let maxRelaunchesInWindow = 3
+
     private static func generateAPIKey() -> String {
         let raw = UUID().uuidString + UUID().uuidString
         return raw.replacingOccurrences(of: "-", with: "").lowercased()
@@ -51,6 +58,23 @@ final class BackendController: ObservableObject {
 
     nonisolated static var logFileURL: URL {
         dataDirectory.appendingPathComponent("backend.log")
+    }
+
+    /// backend.log is opened for append on every launch, so without rotation it
+    /// grows forever. Cap it at a few MB.
+    private static let maxLogBytes: UInt64 = 5 * 1024 * 1024
+
+    /// If the log has exceeded the cap, move it aside to a single `.1` backup
+    /// (overwriting any earlier backup) so the active file starts empty.
+    nonisolated private static func rotateLogIfNeeded(at logURL: URL) {
+        let manager = FileManager.default
+        guard let attributes = try? manager.attributesOfItem(atPath: logURL.path),
+              let size = attributes[.size] as? UInt64, size > maxLogBytes else {
+            return
+        }
+        let rotated = logURL.appendingPathExtension("1")
+        try? manager.removeItem(at: rotated)
+        try? manager.moveItem(at: logURL, to: rotated)
     }
 
     /// Directory of the bundled OCR command-line tools (tesseract, pdftoppm,
@@ -122,8 +146,19 @@ final class BackendController: ObservableObject {
     }
 
     func stop() {
-        process?.terminationHandler = nil
-        process?.terminate()
+        if let running = process {
+            running.terminationHandler = nil
+            running.terminate()
+            // Bounded wait for a graceful exit; escalate so no orphaned
+            // engine survives the app.
+            let deadline = Date().addingTimeInterval(3)
+            while running.isRunning && Date() < deadline {
+                usleep(100_000)
+            }
+            if running.isRunning {
+                kill(running.processIdentifier, SIGKILL)
+            }
+        }
         process = nil
         try? logHandle?.close()
         logHandle = nil
@@ -137,10 +172,30 @@ final class BackendController: ObservableObject {
     /// Stop the embedded backend and start a fresh instance, picking up any
     /// configuration changes from the data directory's .env file.
     func restart() async {
+        let previous = process
         stop()
-        // Give uvicorn a moment to release its port before relaunching.
-        try? await Task.sleep(for: .milliseconds(750))
+        // Wait until the old instance has actually exited (and uvicorn has
+        // released its port) before relaunching, up to 3 seconds.
+        if let previous {
+            var waited = 0
+            while previous.isRunning && waited < 30 {
+                try? await Task.sleep(for: .milliseconds(100))
+                waited += 1
+            }
+        }
         await startEmbeddedIfNeeded()
+    }
+
+    /// Whether the termination handler may auto-relaunch after an unexpected
+    /// exit. Records the attempt and refuses once more than
+    /// `maxRelaunchesInWindow` have occurred inside `relaunchWindow`, so a
+    /// backend that crashes on boot surrenders to `.failed` instead of looping.
+    private func shouldAttemptRelaunch() -> Bool {
+        let now = Date()
+        recentRelaunches.removeAll { now.timeIntervalSince($0) > Self.relaunchWindow }
+        guard recentRelaunches.count < Self.maxRelaunchesInWindow else { return false }
+        recentRelaunches.append(now)
+        return true
     }
 
     func revealDataFolder() {
@@ -168,6 +223,13 @@ final class BackendController: ObservableObject {
         // Environment variables take precedence over a user .env in the data
         // directory, so the per-launch key always applies.
         environment["LIBRARIAN_API_KEY"] = apiKey
+        // Explicitly blank the multi-key variants so a user-writable .env
+        // cannot mint additional API credentials for the embedded engine.
+        environment["LIBRARIAN_API_KEYS"] = ""
+        environment["LIBRARIAN_API_KEY_SHA256"] = ""
+        environment["LIBRARIAN_API_KEY_HASHES"] = ""
+        // Lets the backend detect an orphaned launch (app gone) and exit.
+        environment["LIBRARIAN_PARENT_PID"] = String(ProcessInfo.processInfo.processIdentifier)
         environment["PYTHONUNBUFFERED"] = "1"
         // Provider API keys live in the Keychain, not on disk; hand them to
         // the backend through its environment.
@@ -208,6 +270,11 @@ final class BackendController: ObservableObject {
         launched.currentDirectoryURL = dataDir
 
         let logURL = Self.logFileURL
+        // Keep backend.log from growing without bound: if it has passed the
+        // cap, rotate it to backend.log.1 (replacing any previous rotation)
+        // and start fresh. Every launch appends, so this bounds it to roughly
+        // twice the cap on disk.
+        Self.rotateLogIfNeeded(at: logURL)
         if !FileManager.default.fileExists(atPath: logURL.path) {
             FileManager.default.createFile(atPath: logURL.path, contents: nil)
         }
@@ -225,7 +292,17 @@ final class BackendController: ObservableObject {
                 self.process = nil
                 try? self.logHandle?.close()
                 self.logHandle = nil
-                if case .embedded = self.mode {
+                // Only an *unexpected* exit while we believed the engine was
+                // healthy triggers recovery; a deliberate stop() clears the
+                // termination handler and never reaches here.
+                guard case .embedded = self.mode else { return }
+                if self.shouldAttemptRelaunch() {
+                    // One automatic relaunch attempt: reset to a restartable
+                    // state and boot again. The crash-loop guard prevents this
+                    // from spinning forever.
+                    self.mode = .external
+                    await self.startEmbeddedIfNeeded()
+                } else {
                     self.mode = .failed(
                         "The backend stopped unexpectedly. See backend.log in the data folder."
                     )

--- a/apps/macos/Sources/Librarian/BackendController.swift
+++ b/apps/macos/Sources/Librarian/BackendController.swift
@@ -22,6 +22,13 @@ final class BackendController: ObservableObject {
     private var process: Process?
     private var logHandle: FileHandle?
 
+    /// Ownership token for the boot loop: every user-visible stop or restart
+    /// bumps it, and a suspended `startEmbeddedIfNeeded` aborts when it wakes
+    /// up under a different generation — so toggling the engine off (or
+    /// restarting) mid-boot can never let the old loop relaunch a zombie
+    /// engine or fight a newer boot for `process`.
+    private var bootGeneration = 0
+
     /// Timestamps of recent automatic relaunches after an unexpected exit,
     /// used to detect a crash loop and stop hammering a backend that cannot
     /// stay up instead of restarting it forever.
@@ -115,6 +122,8 @@ final class BackendController: ObservableObject {
             break
         }
         mode = .starting
+        bootGeneration += 1
+        let generation = bootGeneration
         // Fresh credential for every launch: the embedded API requires this
         // key, so other local processes cannot read or modify the corpus.
         let apiKey = Self.generateAPIKey()
@@ -124,9 +133,11 @@ final class BackendController: ObservableObject {
             // A previous (orphaned) instance holds its own per-launch key and
             // cannot be adopted; treat a responding port as occupied.
             if await Self.isLibrarianHealthy(port: port) {
+                guard generation == bootGeneration else { return }
                 occupiedPorts += 1
                 continue
             }
+            guard generation == bootGeneration else { return }
             do {
                 try launch(port: port, apiKey: apiKey)
             } catch {
@@ -138,26 +149,34 @@ final class BackendController: ObservableObject {
             // while the process is alive, and bail out as soon as it exits so
             // the next candidate port is tried without burning the full budget.
             for _ in 0..<240 {
+                guard generation == bootGeneration else { return }
                 if process?.isRunning != true { break }
                 if await Self.isLibrarianHealthy(port: port) {
+                    guard generation == bootGeneration else { return }
                     mode = .embedded(port: port)
                     return
                 }
                 try? await Task.sleep(for: .milliseconds(250))
             }
+            guard generation == bootGeneration else { return }
             let ranFullBudget = process?.isRunning == true
-            await stopGracefully(preserveMode: true)
+            await terminateProcess()
+            guard generation == bootGeneration else { return }
             if ranFullBudget {
                 // The engine ran for the whole budget without answering; a
                 // different port will not help, so surface the failure now.
                 break
             }
         }
+        guard generation == bootGeneration else { return }
         if occupiedPorts == Self.candidatePorts.count {
+            // Every candidate port answered /health, meaning previous engine
+            // instances are still running (they hold per-launch keys and
+            // cannot be adopted).
             mode = .failed(
-                "Other programs are using the engine's ports "
-                    + "(\(Self.candidatePorts.map(String.init).joined(separator: ", "))). "
-                    + "Quit them or restart your Mac, then try again."
+                "A previous engine instance is still running on the engine's "
+                    + "ports (\(Self.candidatePorts.map(String.init).joined(separator: ", "))). "
+                    + "Quit other copies of Librarian or restart your Mac, then try again."
             )
             return
         }
@@ -170,6 +189,7 @@ final class BackendController: ObservableObject {
     /// only way to guarantee no orphaned engine survives the app. UI paths
     /// (settings toggles, restarts) use `stopGracefully()` instead.
     func stop() {
+        bootGeneration += 1
         if let running = process {
             running.terminationHandler = nil
             running.terminate()
@@ -193,10 +213,24 @@ final class BackendController: ObservableObject {
         }
     }
 
-    /// Async stop that never blocks the main actor: terminate, await exit for
-    /// up to 3 s, then SIGKILL. `preserveMode` keeps the current mode (used
-    /// mid-boot, where the caller sets the final mode itself).
-    func stopGracefully(preserveMode: Bool = false) async {
+    /// Async stop that never blocks the main actor. Bumps the boot generation
+    /// so any in-flight `startEmbeddedIfNeeded` aborts instead of relaunching
+    /// against the user's intent.
+    func stopGracefully() async {
+        bootGeneration += 1
+        await terminateProcess()
+        if case .embedded = mode {
+            mode = .external
+        } else if case .starting = mode {
+            mode = .external
+        }
+    }
+
+    /// Terminate the child process and release the log handle without touching
+    /// `mode` or the boot generation. Internal building block: the boot loop
+    /// uses it between port attempts (aborting its own boot would deadlock the
+    /// rotation), and the public stops wrap it.
+    private func terminateProcess() async {
         if let running = process {
             running.terminationHandler = nil
             running.terminate()
@@ -212,13 +246,6 @@ final class BackendController: ObservableObject {
         process = nil
         try? logHandle?.close()
         logHandle = nil
-        if !preserveMode {
-            if case .embedded = mode {
-                mode = .external
-            } else if case .starting = mode {
-                mode = .external
-            }
-        }
     }
 
     /// Stop the embedded backend and start a fresh instance, picking up any

--- a/apps/macos/Sources/Librarian/BackendController.swift
+++ b/apps/macos/Sources/Librarian/BackendController.swift
@@ -119,10 +119,12 @@ final class BackendController: ObservableObject {
         // key, so other local processes cannot read or modify the corpus.
         let apiKey = Self.generateAPIKey()
         embeddedAPIKey = apiKey
+        var occupiedPorts = 0
         for port in Self.candidatePorts {
             // A previous (orphaned) instance holds its own per-launch key and
             // cannot be adopted; treat a responding port as occupied.
             if await Self.isLibrarianHealthy(port: port) {
+                occupiedPorts += 1
                 continue
             }
             do {
@@ -130,7 +132,12 @@ final class BackendController: ObservableObject {
             } catch {
                 continue
             }
-            for _ in 0..<60 {
+            // A cold first launch (relocatable Python start + migrations) can
+            // legitimately take tens of seconds; killing a healthy boot at 15 s
+            // read as "Engine didn't start" on slower Macs. Wait up to 60 s
+            // while the process is alive, and bail out as soon as it exits so
+            // the next candidate port is tried without burning the full budget.
+            for _ in 0..<240 {
                 if process?.isRunning != true { break }
                 if await Self.isLibrarianHealthy(port: port) {
                     mode = .embedded(port: port)
@@ -138,13 +145,30 @@ final class BackendController: ObservableObject {
                 }
                 try? await Task.sleep(for: .milliseconds(250))
             }
-            stop()
+            let ranFullBudget = process?.isRunning == true
+            await stopGracefully(preserveMode: true)
+            if ranFullBudget {
+                // The engine ran for the whole budget without answering; a
+                // different port will not help, so surface the failure now.
+                break
+            }
+        }
+        if occupiedPorts == Self.candidatePorts.count {
+            mode = .failed(
+                "Other programs are using the engine's ports "
+                    + "(\(Self.candidatePorts.map(String.init).joined(separator: ", "))). "
+                    + "Quit them or restart your Mac, then try again."
+            )
+            return
         }
         mode = .failed(
             "The embedded backend did not start. See backend.log in the data folder."
         )
     }
 
+    /// Synchronous stop for app termination, where blocking briefly is the
+    /// only way to guarantee no orphaned engine survives the app. UI paths
+    /// (settings toggles, restarts) use `stopGracefully()` instead.
     func stop() {
         if let running = process {
             running.terminationHandler = nil
@@ -169,20 +193,40 @@ final class BackendController: ObservableObject {
         }
     }
 
-    /// Stop the embedded backend and start a fresh instance, picking up any
-    /// configuration changes from the data directory's .env file.
-    func restart() async {
-        let previous = process
-        stop()
-        // Wait until the old instance has actually exited (and uvicorn has
-        // released its port) before relaunching, up to 3 seconds.
-        if let previous {
+    /// Async stop that never blocks the main actor: terminate, await exit for
+    /// up to 3 s, then SIGKILL. `preserveMode` keeps the current mode (used
+    /// mid-boot, where the caller sets the final mode itself).
+    func stopGracefully(preserveMode: Bool = false) async {
+        if let running = process {
+            running.terminationHandler = nil
+            running.terminate()
             var waited = 0
-            while previous.isRunning && waited < 30 {
+            while running.isRunning && waited < 30 {
                 try? await Task.sleep(for: .milliseconds(100))
                 waited += 1
             }
+            if running.isRunning {
+                kill(running.processIdentifier, SIGKILL)
+            }
         }
+        process = nil
+        try? logHandle?.close()
+        logHandle = nil
+        if !preserveMode {
+            if case .embedded = mode {
+                mode = .external
+            } else if case .starting = mode {
+                mode = .external
+            }
+        }
+    }
+
+    /// Stop the embedded backend and start a fresh instance, picking up any
+    /// configuration changes from the data directory's .env file.
+    func restart() async {
+        // stopGracefully waits for the old instance to exit (and uvicorn to
+        // release its port) before we relaunch.
+        await stopGracefully()
         await startEmbeddedIfNeeded()
     }
 

--- a/apps/macos/Sources/Librarian/BackendController.swift
+++ b/apps/macos/Sources/Librarian/BackendController.swift
@@ -1,6 +1,12 @@
 import AppKit
 import Foundation
 
+/// backend.log is opened for append on every launch, so without rotation it
+/// grows forever. Cap it at a few MB. File-scope (not a static on the
+/// @MainActor class) so the nonisolated log-rotation helper can read it
+/// without crossing actor isolation — that reference is an error in Swift 6.
+private let backendMaxLogBytes: UInt64 = 5 * 1024 * 1024
+
 /// Launches and supervises the Librarian backend that ships inside the app
 /// bundle (Contents/Resources/backend). Falls back to an external server when
 /// no bundled backend is present or the user disables embedded mode.
@@ -67,16 +73,12 @@ final class BackendController: ObservableObject {
         dataDirectory.appendingPathComponent("backend.log")
     }
 
-    /// backend.log is opened for append on every launch, so without rotation it
-    /// grows forever. Cap it at a few MB.
-    private static let maxLogBytes: UInt64 = 5 * 1024 * 1024
-
     /// If the log has exceeded the cap, move it aside to a single `.1` backup
     /// (overwriting any earlier backup) so the active file starts empty.
     nonisolated private static func rotateLogIfNeeded(at logURL: URL) {
         let manager = FileManager.default
         guard let attributes = try? manager.attributesOfItem(atPath: logURL.path),
-              let size = attributes[.size] as? UInt64, size > maxLogBytes else {
+              let size = attributes[.size] as? UInt64, size > backendMaxLogBytes else {
             return
         }
         let rotated = logURL.appendingPathExtension("1")

--- a/apps/macos/Sources/Librarian/Copy.swift
+++ b/apps/macos/Sources/Librarian/Copy.swift
@@ -23,7 +23,23 @@ enum Copy {
     static let openFile = "Open"
     static let removeFromList = "Remove from list"
     static let retry = "Retry"
+    static let stop = "Stop"
     static let clearFinished = "Clear Finished"
+    static let addFiles = "Add Files…"
+    static let failureDetails = "Details"
+    static let failureDetailsEmpty = "No further detail was recorded."
+
+    static let libraryTitle = "Library"
+    static let librarySearchPrompt = "Search your cleaned documents"
+    static let libraryEmpty = "Documents you process appear here."
+    static let libraryNoMatches = "No matches — try different words."
+    static let librarySaveCopy = "Save a Copy"
+    static let libraryDelete = "Delete…"
+    static let libraryDeleteConfirmTitle = "Delete this document?"
+    static func libraryDeleteConfirmBody(_ filename: String) -> String {
+        "\"\(filename)\" and its cleaned text will be removed from the app. "
+            + "Files already saved to your folder are not touched."
+    }
 
     static func footerActive(_ current: Int, of total: Int) -> String {
         "Cleaning \(current) of \(total)"
@@ -63,6 +79,14 @@ enum Copy {
 
     static let reasonTimeout = "Took too long — try again"
     static let reasonInterrupted = "Interrupted"
+    static let reasonStopped = "Stopped"
+
+    static let okfSyncFailed =
+        "The bundle couldn't be updated — it will retry after the next finished file."
+    static func okfSkipped(_ count: Int) -> String {
+        "\(count) document\(count == 1 ? " was" : "s were") left out of the bundle "
+            + "(not processed yet)."
+    }
 
     /// Translate backend failure text into plain words. All failure copy
     /// lives here so wording stays in one place.

--- a/apps/macos/Sources/Librarian/Copy.swift
+++ b/apps/macos/Sources/Librarian/Copy.swift
@@ -59,6 +59,7 @@ enum Copy {
         "Connected — using \(model)"
     }
     static let providerKeyFailed = "Key didn't work — check it and try again."
+    static let keychainSaveFailed = "Could not save the key to the Keychain."
 
     static let reasonTimeout = "Took too long — try again"
     static let reasonInterrupted = "Interrupted"

--- a/apps/macos/Sources/Librarian/KeychainStore.swift
+++ b/apps/macos/Sources/Librarian/KeychainStore.swift
@@ -22,7 +22,10 @@ enum KeychainStore {
         return String(data: data, encoding: .utf8)
     }
 
-    static func set(_ value: String, account: String) {
+    /// Returns false when the Keychain rejects the write, so callers can
+    /// tell the user instead of silently losing the key.
+    @discardableResult
+    static func set(_ value: String, account: String) -> Bool {
         let encoded = Data(value.utf8)
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -34,8 +37,9 @@ enum KeychainStore {
         if status == errSecItemNotFound {
             var insert = query
             insert[kSecValueData as String] = encoded
-            SecItemAdd(insert as CFDictionary, nil)
+            return SecItemAdd(insert as CFDictionary, nil) == errSecSuccess
         }
+        return status == errSecSuccess
     }
 
     static func delete(_ account: String) {
@@ -61,6 +65,17 @@ enum ProviderCredentials {
         for account in knownKeyAccounts {
             if let value = KeychainStore.get(account), !value.isEmpty {
                 overlay[account] = value
+            }
+        }
+        // Local servers (Ollama, LM Studio, keyless custom) store no key in
+        // the Keychain, but the OpenAI-compatible client requires a non-empty
+        // one. Hand the spawned process a transient placeholder; it is never
+        // persisted anywhere.
+        let values = EnvFile.read()
+        if values["LIBRARIAN_LLM_PROVIDER"] == "openai-compatible" {
+            let keyEnv = values["LIBRARIAN_LLM_API_KEY_ENV"] ?? "OPENAI_API_KEY"
+            if overlay[keyEnv] == nil {
+                overlay[keyEnv] = "local"
             }
         }
         return overlay

--- a/apps/macos/Sources/Librarian/LibrarianApp.swift
+++ b/apps/macos/Sources/Librarian/LibrarianApp.swift
@@ -34,6 +34,25 @@ struct LibrarianApp: App {
                 .environmentObject(model)
                 .tint(Self.tint)
                 .toolbar {
+                    // Adding files must not depend on the empty-state button or
+                    // drag-and-drop: once the queue is non-empty those vanish,
+                    // and keyboard/VoiceOver users need a persistent control.
+                    ToolbarItem(placement: .automatic) {
+                        Button {
+                            model.presentChooseFilesPanel()
+                        } label: {
+                            Label(Copy.addFiles, systemImage: "plus")
+                        }
+                        .help("Add documents to clean")
+                    }
+                    ToolbarItem(placement: .automatic) {
+                        OpenAuxiliaryWindowButton(
+                            title: Copy.libraryTitle,
+                            systemImage: "books.vertical",
+                            windowID: "library"
+                        )
+                        .help("Browse and search everything you've processed")
+                    }
                     ToolbarItem(placement: .primaryAction) {
                         SettingsLink {
                             Label("Settings", systemImage: "gearshape")
@@ -47,7 +66,18 @@ struct LibrarianApp: App {
         }
         .defaultSize(width: 680, height: 520)
         .commands {
+            CommandGroup(replacing: .newItem) {
+                Button(Copy.addFiles) {
+                    model.presentChooseFilesPanel()
+                }
+                .keyboardShortcut("o")
+            }
             CommandMenu("Tools") {
+                OpenAuxiliaryWindowButton(
+                    title: "\(Copy.libraryTitle)…",
+                    windowID: "library"
+                )
+                .keyboardShortcut("l")
                 OpenAuxiliaryWindowButton(
                     title: "File & Transcript Tools…",
                     windowID: "tools"
@@ -57,6 +87,13 @@ struct LibrarianApp: App {
                 OpenAuxiliaryWindowButton(title: "Diagnostics…", windowID: "diagnostics")
             }
         }
+
+        Window(Copy.libraryTitle, id: "library") {
+            LibraryView()
+                .environmentObject(model)
+                .tint(Self.tint)
+        }
+        .defaultSize(width: 640, height: 460)
 
         Window("Tools", id: "tools") {
             ToolsView()
@@ -84,11 +121,18 @@ struct LibrarianApp: App {
 private struct OpenAuxiliaryWindowButton: View {
     @Environment(\.openWindow) private var openWindow
     let title: String
+    var systemImage: String?
     let windowID: String
 
     var body: some View {
-        Button(title) {
+        Button {
             openWindow(id: windowID)
+        } label: {
+            if let systemImage {
+                Label(title, systemImage: systemImage)
+            } else {
+                Text(title)
+            }
         }
     }
 }

--- a/apps/macos/Sources/Librarian/Views/ContentView.swift
+++ b/apps/macos/Sources/Librarian/Views/ContentView.swift
@@ -130,6 +130,7 @@ struct QueueRowView: View {
     let item: QueueItem
     @State private var showFailureDetails = false
     @State private var failureEvents: [RunEvent] = []
+    @State private var isLoadingFailureEvents = false
 
     var body: some View {
         HStack(spacing: 10) {
@@ -228,17 +229,25 @@ struct QueueRowView: View {
             HStack(spacing: 8) {
                 if item.runID != nil {
                     Button(Copy.failureDetails) {
+                        // Open immediately with a loading state; a slow or
+                        // unreachable engine must not make the button feel dead.
+                        showFailureDetails = true
+                        isLoadingFailureEvents = true
                         let runID = item.runID
                         Task { @MainActor in
                             if let runID {
                                 failureEvents = await model.failureEvents(runID: runID)
                             }
-                            showFailureDetails = true
+                            isLoadingFailureEvents = false
                         }
                     }
                     .buttonStyle(.link)
                     .popover(isPresented: $showFailureDetails) {
-                        FailureDetailsView(item: item, events: failureEvents)
+                        FailureDetailsView(
+                            item: item,
+                            events: failureEvents,
+                            isLoading: isLoadingFailureEvents
+                        )
                     }
                 }
                 if retryable {
@@ -314,6 +323,7 @@ struct QueueRowView: View {
 struct FailureDetailsView: View {
     let item: QueueItem
     let events: [RunEvent]
+    var isLoading: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -327,7 +337,14 @@ struct FailureDetailsView: View {
                     .foregroundStyle(.orange)
             }
             Divider()
-            if events.isEmpty {
+            if isLoading && events.isEmpty {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Loading…")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            } else if events.isEmpty {
                 Text(Copy.failureDetailsEmpty)
                     .font(.callout)
                     .foregroundStyle(.secondary)

--- a/apps/macos/Sources/Librarian/Views/ContentView.swift
+++ b/apps/macos/Sources/Librarian/Views/ContentView.swift
@@ -62,6 +62,11 @@ struct ContentView: View {
         }
         .listStyle(.inset)
         .scrollContentBackground(.hidden)
+        .onDeleteCommand {
+            if let selection {
+                model.remove(selection)
+            }
+        }
     }
 }
 
@@ -123,6 +128,8 @@ struct QueueRowView: View {
     @EnvironmentObject private var model: AppModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let item: QueueItem
+    @State private var showFailureDetails = false
+    @State private var failureEvents: [RunEvent] = []
 
     var body: some View {
         HStack(spacing: 10) {
@@ -132,6 +139,7 @@ struct QueueRowView: View {
                 .frame(width: 24)
                 .transition(reduceMotion ? .opacity : .scale.combined(with: .opacity))
                 .id(leadingSymbol)
+                .accessibilityLabel(stageAccessibilityLabel)
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(item.filename)
@@ -150,6 +158,9 @@ struct QueueRowView: View {
             if case .done(let outputURL) = item.stage {
                 Button(Copy.showInFinder) { model.revealInFinder(outputURL) }
                 Button(Copy.openFile) { model.openFile(outputURL) }
+            }
+            if !item.stage.isTerminal {
+                Button(Copy.stop) { model.stop(item.id) }
             }
             Button(Copy.removeFromList) { model.remove(item.id) }
         }
@@ -214,14 +225,51 @@ struct QueueRowView: View {
             .buttonStyle(.link)
             .transition(reduceMotion ? .opacity : .move(edge: .trailing).combined(with: .opacity))
         case .failed(_, let retryable):
-            if retryable {
-                Button(Copy.retry) {
-                    model.retry(item.id)
+            HStack(spacing: 8) {
+                if item.runID != nil {
+                    Button(Copy.failureDetails) {
+                        let runID = item.runID
+                        Task { @MainActor in
+                            if let runID {
+                                failureEvents = await model.failureEvents(runID: runID)
+                            }
+                            showFailureDetails = true
+                        }
+                    }
+                    .buttonStyle(.link)
+                    .popover(isPresented: $showFailureDetails) {
+                        FailureDetailsView(item: item, events: failureEvents)
+                    }
                 }
-                .buttonStyle(.bordered)
+                if retryable {
+                    Button(Copy.retry) {
+                        model.retry(item.id)
+                    }
+                    .buttonStyle(.bordered)
+                }
             }
-        default:
+        case .queued, .uploading:
             EmptyView()
+        default:
+            // Converting/cleaning/classifying: the engine is spending real
+            // provider tokens, so stopping must not require the context menu.
+            Button(Copy.stop) {
+                model.stop(item.id)
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private var stageAccessibilityLabel: String {
+        switch item.stage {
+        case .queued: return Copy.stageWaiting
+        case .uploading: return Copy.stageSending
+        case .converting: return Copy.stageConverting
+        case .cleaning: return Copy.stageCleaning
+        case .classifying: return Copy.stageClassifying
+        case .done: return Copy.stageSaved
+        case .failed(let reason, _): return reason
         }
     }
 
@@ -255,6 +303,56 @@ struct QueueRowView: View {
         default:
             return "doc.text"
         }
+    }
+}
+
+// MARK: - Failure details
+
+/// The engine's per-run event log for a failed row, so a failure is more than
+/// one summarized line. Read-only; the last few events usually name the stage
+/// and error that sank the file.
+struct FailureDetailsView: View {
+    let item: QueueItem
+    let events: [RunEvent]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(item.filename)
+                .font(.headline)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if case .failed(let reason, _) = item.stage {
+                Text(reason)
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+            }
+            Divider()
+            if events.isEmpty {
+                Text(Copy.failureDetailsEmpty)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(events) { event in
+                            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                Text(event.stage)
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 70, alignment: .leading)
+                                Text(event.message)
+                                    .font(.caption)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 220)
+            }
+        }
+        .padding(14)
+        .frame(width: 420)
     }
 }
 
@@ -298,6 +396,14 @@ struct FooterView: View {
         HStack(spacing: 10) {
             aggregateStatus
             enginePill
+            if let notice = model.okfSyncNotice {
+                Label(notice, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .help(notice)
+            }
             Spacer()
             if model.queue.contains(where: { $0.stage.isDone }) {
                 Button(Copy.clearFinished) {

--- a/apps/macos/Sources/Librarian/Views/ContentView.swift
+++ b/apps/macos/Sources/Librarian/Views/ContentView.swift
@@ -38,6 +38,17 @@ struct ContentView: View {
                 DropOverlayView()
             }
         }
+        .alert(
+            "Some files were skipped",
+            isPresented: Binding(
+                get: { model.skippedFilesNotice != nil },
+                set: { if !$0 { model.skippedFilesNotice = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { model.skippedFilesNotice = nil }
+        } message: {
+            Text(model.skippedFilesNotice ?? "")
+        }
         .task {
             model.startPolling()
         }

--- a/apps/macos/Sources/Librarian/Views/DiagnosticsView.swift
+++ b/apps/macos/Sources/Librarian/Views/DiagnosticsView.swift
@@ -131,6 +131,8 @@ struct DiagnosticsView: View {
                         }
                         .disabled(!BackendController.isEmbeddedAvailable ||
                             !model.useEmbeddedBackend)
+                    }
+                    HStack(spacing: 10) {
                         Button("Data Folder") {
                             model.backend.revealDataFolder()
                         }
@@ -183,6 +185,11 @@ struct DiagnosticsView: View {
            let report = try? JSONDecoder().decode(DoctorReport.self, from: data) {
             checks = report.checks
         }
+        // Refresh also re-reads the effective configuration when it has
+        // already been shown once.
+        if configText != nil {
+            await loadConfig()
+        }
     }
 
     private func migrate() async {
@@ -211,9 +218,15 @@ struct DiagnosticsView: View {
                 "admin", "db-maintain", "--prune-cache-days", "30", "--vacuum",
             ])
             let text = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
-            actionOutput = text.isEmpty
-                ? (result.succeeded ? "Done." : "Reclaim failed — see backend.log.")
-                : text
+            if result.succeeded {
+                actionOutput = text.isEmpty ? "Done." : text
+            } else if text.lowercased().contains("locked") || text.lowercased().contains("busy") {
+                // VACUUM needs the database to itself; the live engine holds
+                // it open while files are processing.
+                actionOutput = "The engine is busy — try again when nothing is processing."
+            } else {
+                actionOutput = text.isEmpty ? "Reclaim failed — see backend.log." : text
+            }
         } catch {
             actionOutput = error.localizedDescription
         }

--- a/apps/macos/Sources/Librarian/Views/DiagnosticsView.swift
+++ b/apps/macos/Sources/Librarian/Views/DiagnosticsView.swift
@@ -12,6 +12,15 @@ struct DiagnosticsView: View {
     @State private var isLoading = false
     @State private var actionOutput: String?
     @State private var isMigrating = false
+    @State private var isReclaiming = false
+    @State private var configText: String?
+
+    /// What the readiness rows show while unknown: a spinner-stand-in when the
+    /// engine is reachable, an honest "offline" when it is not — never an
+    /// eternal "…".
+    private var pendingDetail: String {
+        model.serverOnline ? "…" : "offline"
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -19,6 +28,12 @@ struct DiagnosticsView: View {
                 Text("Diagnostics")
                     .font(.title2.weight(.semibold))
                 Spacer()
+                Button {
+                    Task { await load() }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .disabled(isLoading)
                 Button("Done") { dismiss() }
                     .keyboardShortcut(.defaultAction)
             }
@@ -28,22 +43,22 @@ struct DiagnosticsView: View {
                     ChecklistRowView(
                         ok: model.serverOnline,
                         title: "Server",
-                        detail: version.map { "v\($0)" } ?? (model.serverOnline ? "…" : "offline")
+                        detail: version.map { "v\($0)" } ?? pendingDetail
                     )
                     ChecklistRowView(
                         ok: readiness?.database == "ok",
                         title: "Database",
-                        detail: readiness?.database ?? "…"
+                        detail: readiness?.database ?? pendingDetail
                     )
                     ChecklistRowView(
                         ok: readiness?.storage == "ok",
                         title: "Storage",
-                        detail: readiness?.storage ?? "…"
+                        detail: readiness?.storage ?? pendingDetail
                     )
                     ChecklistRowView(
                         ok: (readiness?.appliedMigrations ?? 0) > 0,
                         title: "Migrations",
-                        detail: readiness.map { "\($0.appliedMigrations) applied" } ?? "…"
+                        detail: readiness.map { "\($0.appliedMigrations) applied" } ?? pendingDetail
                     )
                 }
                 .padding(6)
@@ -100,6 +115,14 @@ struct DiagnosticsView: View {
                             Task { await migrate() }
                         }
                         .disabled(isMigrating || !BackendCLI.isAvailable)
+                        Button(isReclaiming ? "Reclaiming…" : "Reclaim Disk Space") {
+                            Task { await reclaimDiskSpace() }
+                        }
+                        .disabled(isReclaiming || !BackendCLI.isAvailable)
+                        .help(
+                            "Removes cached work older than 30 days and compacts "
+                                + "the database. Your documents are not touched."
+                        )
                         Button("Restart Backend") {
                             Task {
                                 await model.restartBackend()
@@ -123,6 +146,25 @@ struct DiagnosticsView: View {
                     }
                 }
                 .padding(6)
+            }
+
+            if BackendCLI.isAvailable {
+                DisclosureGroup("Effective configuration") {
+                    ScrollView {
+                        Text(configText ?? "Loading…")
+                            .font(.caption.monospaced())
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(6)
+                    }
+                    .frame(height: 180)
+                    .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 6))
+                    .task {
+                        if configText == nil {
+                            await loadConfig()
+                        }
+                    }
+                }
             }
         }
         .padding(20)
@@ -156,6 +198,38 @@ struct DiagnosticsView: View {
         } catch {
             actionOutput = error.localizedDescription
         }
+    }
+
+    /// Prune caches older than 30 days and compact the database. The engine's
+    /// caches only speed up re-processing of identical content; removing old
+    /// entries never loses documents.
+    private func reclaimDiskSpace() async {
+        isReclaiming = true
+        defer { isReclaiming = false }
+        do {
+            let result = try await BackendCLI.run([
+                "admin", "db-maintain", "--prune-cache-days", "30", "--vacuum",
+            ])
+            let text = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+            actionOutput = text.isEmpty
+                ? (result.succeeded ? "Done." : "Reclaim failed — see backend.log.")
+                : text
+        } catch {
+            actionOutput = error.localizedDescription
+        }
+    }
+
+    /// The engine's full effective configuration with secrets redacted,
+    /// via `admin config --json` — the support answer to "what is it
+    /// actually running with?".
+    private func loadConfig() async {
+        guard let result = try? await BackendCLI.run(["admin", "config", "--json"]),
+              result.succeeded else {
+            configText = "Configuration unavailable."
+            return
+        }
+        let text = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        configText = text.isEmpty ? "Configuration unavailable." : text
     }
 }
 

--- a/apps/macos/Sources/Librarian/Views/LibraryView.swift
+++ b/apps/macos/Sources/Librarian/Views/LibraryView.swift
@@ -36,8 +36,9 @@ struct LibraryView: View {
                     ProgressView().controlSize(.small)
                 } else if !query.isEmpty {
                     Button {
+                        // onChange(of: query) below owns the reload; calling
+                        // scheduleSearch here too would race it.
                         query = ""
-                        scheduleSearch(immediate: true)
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundStyle(.secondary)
@@ -49,7 +50,9 @@ struct LibraryView: View {
             .padding(10)
             .background(.bar)
             .onChange(of: query) {
-                scheduleSearch(immediate: false)
+                // Emptying the field (clear button, select-all-delete) shows
+                // the full library immediately; typing debounces.
+                scheduleSearch(immediate: query.isEmpty)
             }
 
             Divider()
@@ -153,22 +156,28 @@ struct LibraryView: View {
             }
             notice = nil
         } catch {
+            // A newer keystroke cancelled this reload; keep showing the
+            // current rows rather than blanking the list with an error the
+            // replacement reload is about to overwrite.
+            if Task.isCancelled { return }
             rows = []
             notice = Copy.userFacingReason(for: error.localizedDescription)
         }
     }
 
     /// The engine returns snippets HTML-escaped with `<mark>` highlight tags
-    /// (for web clients); render them as plain text here.
+    /// (for web clients); render them as plain text here. `&amp;` must be
+    /// unescaped LAST: document text "&lt;" arrives as "&amp;lt;", and
+    /// unescaping the ampersand first would double-unescape it to "<".
     static func plainSnippet(_ raw: String) -> String {
         raw
             .replacingOccurrences(of: "<mark>", with: "")
             .replacingOccurrences(of: "</mark>", with: "")
-            .replacingOccurrences(of: "&amp;", with: "&")
             .replacingOccurrences(of: "&lt;", with: "<")
             .replacingOccurrences(of: "&gt;", with: ">")
             .replacingOccurrences(of: "&quot;", with: "\"")
             .replacingOccurrences(of: "&#x27;", with: "'")
+            .replacingOccurrences(of: "&amp;", with: "&")
             .replacingOccurrences(of: "\n", with: " ")
     }
 

--- a/apps/macos/Sources/Librarian/Views/LibraryView.swift
+++ b/apps/macos/Sources/Librarian/Views/LibraryView.swift
@@ -1,0 +1,253 @@
+import SwiftUI
+
+/// One row in the Library window, flattened from either a browsed document or
+/// a search match so the list renders both identically.
+struct LibraryRow: Identifiable, Hashable {
+    let id: String
+    let documentID: String
+    let filename: String
+    let snippet: String?
+    let classificationLabel: String?
+}
+
+/// Browse and search everything the engine has processed. Full-text search
+/// runs on the engine (with word-stem matching), so "dividend" finds
+/// "dividends". Rows offer Save a Copy (re-export into the destination
+/// folder) and Delete.
+struct LibraryView: View {
+    @EnvironmentObject private var model: AppModel
+
+    @State private var query = ""
+    @State private var rows: [LibraryRow] = []
+    @State private var isLoading = false
+    @State private var notice: String?
+    @State private var pendingDelete: LibraryRow?
+    @State private var searchTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField(Copy.librarySearchPrompt, text: $query)
+                    .textFieldStyle(.plain)
+                    .onSubmit { scheduleSearch(immediate: true) }
+                if isLoading {
+                    ProgressView().controlSize(.small)
+                } else if !query.isEmpty {
+                    Button {
+                        query = ""
+                        scheduleSearch(immediate: true)
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                }
+            }
+            .padding(10)
+            .background(.bar)
+            .onChange(of: query) {
+                scheduleSearch(immediate: false)
+            }
+
+            Divider()
+
+            if rows.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: query.isEmpty ? "books.vertical" : "magnifyingglass")
+                        .font(.system(size: 36, weight: .light))
+                        .foregroundStyle(.secondary)
+                    Text(query.isEmpty ? Copy.libraryEmpty : Copy.libraryNoMatches)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(rows) { row in
+                    LibraryRowView(
+                        row: row,
+                        onSave: { save(row) },
+                        onDelete: { pendingDelete = row }
+                    )
+                    .listRowSeparator(.visible)
+                }
+                .listStyle(.inset)
+                .scrollContentBackground(.hidden)
+            }
+
+            if let notice {
+                Divider()
+                Text(notice)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .padding(8)
+            }
+        }
+        .frame(minWidth: 560, minHeight: 380)
+        .task { await reload() }
+        .confirmationDialog(
+            Copy.libraryDeleteConfirmTitle,
+            isPresented: Binding(
+                get: { pendingDelete != nil },
+                set: { if !$0 { pendingDelete = nil } }
+            ),
+            presenting: pendingDelete
+        ) { row in
+            Button(role: .destructive) {
+                delete(row)
+            } label: {
+                Text("Delete \"\(row.filename)\"")
+            }
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+        } message: { row in
+            Text(Copy.libraryDeleteConfirmBody(row.filename))
+        }
+    }
+
+    // MARK: - Data
+
+    /// Debounce keystrokes; run immediately on submit/clear.
+    private func scheduleSearch(immediate: Bool) {
+        searchTask?.cancel()
+        searchTask = Task { @MainActor in
+            if !immediate {
+                try? await Task.sleep(for: .milliseconds(300))
+                if Task.isCancelled { return }
+            }
+            await reload()
+        }
+    }
+
+    private func reload() async {
+        isLoading = true
+        defer { isLoading = false }
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            if trimmed.isEmpty {
+                let page = try await model.client.listDocuments()
+                rows = page.documents
+                    .filter { $0.status == "ready" }
+                    .map { document in
+                        LibraryRow(
+                            id: "doc-\(document.id)",
+                            documentID: document.id,
+                            filename: document.filename,
+                            snippet: nil,
+                            classificationLabel: nil
+                        )
+                    }
+            } else {
+                let results = try await model.client.search(query: trimmed)
+                rows = results.map { result in
+                    LibraryRow(
+                        id: "hit-\(result.id)",
+                        documentID: result.documentId,
+                        filename: result.filename,
+                        snippet: Self.plainSnippet(result.snippet),
+                        classificationLabel: result.classificationLabel
+                    )
+                }
+            }
+            notice = nil
+        } catch {
+            rows = []
+            notice = Copy.userFacingReason(for: error.localizedDescription)
+        }
+    }
+
+    /// The engine returns snippets HTML-escaped with `<mark>` highlight tags
+    /// (for web clients); render them as plain text here.
+    static func plainSnippet(_ raw: String) -> String {
+        raw
+            .replacingOccurrences(of: "<mark>", with: "")
+            .replacingOccurrences(of: "</mark>", with: "")
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#x27;", with: "'")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+
+    // MARK: - Actions
+
+    private func save(_ row: LibraryRow) {
+        let stem = (row.filename as NSString).deletingPathExtension
+        Task { @MainActor in
+            do {
+                let written = try await model.exportDocumentToFolder(
+                    documentID: row.documentID,
+                    fallbackStem: stem
+                )
+                notice = "Saved \(written.lastPathComponent)"
+                model.revealInFinder(written)
+            } catch {
+                notice = Copy.userFacingReason(for: error.localizedDescription)
+            }
+        }
+    }
+
+    private func delete(_ row: LibraryRow) {
+        pendingDelete = nil
+        Task { @MainActor in
+            do {
+                try await model.deleteDocument(id: row.documentID)
+                rows.removeAll { $0.documentID == row.documentID }
+                notice = "Deleted \(row.filename)"
+            } catch {
+                notice = Copy.userFacingReason(for: error.localizedDescription)
+            }
+        }
+    }
+}
+
+struct LibraryRowView: View {
+    let row: LibraryRow
+    let onSave: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "doc.text")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(row.filename)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let label = row.classificationLabel {
+                        Text(label)
+                            .font(.caption)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(.tint.opacity(0.12), in: Capsule())
+                    }
+                }
+                if let snippet = row.snippet {
+                    Text(snippet)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer()
+
+            Button(Copy.librarySaveCopy, action: onSave)
+                .buttonStyle(.link)
+        }
+        .frame(minHeight: 40)
+        .contextMenu {
+            Button(Copy.librarySaveCopy, action: onSave)
+            Divider()
+            Button(Copy.libraryDelete, role: .destructive, action: onDelete)
+        }
+    }
+}

--- a/apps/macos/Sources/Librarian/Views/SettingsView.swift
+++ b/apps/macos/Sources/Librarian/Views/SettingsView.swift
@@ -382,22 +382,20 @@ struct SettingsView: View {
 
     /// Persist the Advanced engine options and restart the engine so they
     /// apply. Defaults are removed from the file rather than written, so a
-    /// hand-edited .env only carries deliberate overrides.
+    /// hand-edited .env only carries deliberate overrides. Diffed against the
+    /// file first: onChange also fires when state is restored on open, and a
+    /// no-op "apply" must never restart the engine (killing in-flight runs).
     private func applyEngineOptions() async {
-        var updates: [String: String?] = [:]
-        updates.updateValue(
-            coherenceMode == "balanced" ? nil : coherenceMode,
-            forKey: "LIBRARIAN_COHERENCE_MODE"
-        )
-        updates.updateValue(
-            figureVisionEnabled ? "true" : nil,
-            forKey: "LIBRARIAN_FIGURE_VISION_ENABLED"
-        )
         let visionModel = figureVisionModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        updates.updateValue(
-            (figureVisionEnabled && !visionModel.isEmpty) ? visionModel : nil,
-            forKey: "LIBRARIAN_FIGURE_VISION_MODEL"
-        )
+        let updates: [String: String?] = [
+            "LIBRARIAN_COHERENCE_MODE": coherenceMode == "balanced" ? nil : coherenceMode,
+            "LIBRARIAN_FIGURE_VISION_ENABLED": figureVisionEnabled ? "true" : nil,
+            "LIBRARIAN_FIGURE_VISION_MODEL":
+                (figureVisionEnabled && !visionModel.isEmpty) ? visionModel : nil,
+        ]
+        let current = EnvFile.read()
+        let changed = updates.contains { key, value in current[key] != value }
+        guard changed else { return }
         do {
             try EnvFile.update(updates)
         } catch {

--- a/apps/macos/Sources/Librarian/Views/SettingsView.swift
+++ b/apps/macos/Sources/Librarian/Views/SettingsView.swift
@@ -287,7 +287,10 @@ struct SettingsView: View {
         selectedModel = ""
         manualModel = ""
         customAddress = preset.isLocal ? (preset.configuredBaseURL ?? "") : ""
-        apiKey = KeychainStore.get(preset.keyAccount) ?? ""
+        // Never pre-fill the Custom preset from the shared OPENAI_API_KEY: its
+        // address is user-typed, so a prefilled real key would be sent to an
+        // arbitrary (possibly hostile or mistyped) URL. Require an explicit paste.
+        apiKey = preset == .custom ? "" : (KeychainStore.get(preset.keyAccount) ?? "")
     }
 
     private func loadCurrent() {
@@ -310,7 +313,9 @@ struct SettingsView: View {
         } else {
             preset = .custom
         }
-        apiKey = KeychainStore.get(preset.keyAccount) ?? ""
+        // See resetForPresetChange: the Custom preset must not inherit the
+        // shared OpenAI key, since it would be sent to the user-typed address.
+        apiKey = preset == .custom ? "" : (KeychainStore.get(preset.keyAccount) ?? "")
         customAddress = (preset.isLocal || preset == .custom) ? base : ""
         let current = values["LIBRARIAN_LLM_MODEL"] ?? ""
         if !current.isEmpty {
@@ -355,7 +360,15 @@ struct SettingsView: View {
         guard !chosen.isEmpty else { return }
         phase = .applying
         let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        KeychainStore.set(key.isEmpty ? "local" : key, account: preset.keyAccount)
+        // Only store a key the user actually entered. Local servers (Ollama,
+        // LM Studio, keyless custom) write nothing to the Keychain; the
+        // engine gets a transient placeholder in its environment instead.
+        if !key.isEmpty {
+            guard KeychainStore.set(key, account: preset.keyAccount) else {
+                phase = .failed(Copy.keychainSaveFailed)
+                return
+            }
+        }
 
         var updates: [String: String?] = [:]
         for account in ProviderCredentials.knownKeyAccounts {

--- a/apps/macos/Sources/Librarian/Views/SettingsView.swift
+++ b/apps/macos/Sources/Librarian/Views/SettingsView.swift
@@ -93,6 +93,14 @@ struct SettingsView: View {
     /// saved model on open must not restart the engine.
     @State private var applyOnSelect = false
 
+    // Engine options surfaced from the backend configuration. Guarded by
+    // `engineOptionsLoaded` so restoring saved values on open doesn't
+    // restart the engine.
+    @State private var coherenceMode = "balanced"
+    @State private var figureVisionEnabled = false
+    @State private var figureVisionModel = ""
+    @State private var engineOptionsLoaded = false
+
     @AppStorage(AppModel.keepOriginalsKey) private var keepOriginals = false
     @AppStorage(AppModel.useEmbeddedKey) private var useEmbedded = true
     @AppStorage(AppModel.baseURLKey) private var externalURL = AppModel.defaultBaseURL
@@ -121,6 +129,11 @@ struct SettingsView: View {
                 SecureField("API key", text: $apiKey, prompt: Text(keyPrompt))
                     .textFieldStyle(.roundedBorder)
                     .onSubmit { Task { await connect() } }
+                    .onChange(of: apiKey) {
+                        // A stale "key didn't work" banner over a freshly
+                        // edited key reads as a live failure; clear it.
+                        if case .failed = phase { phase = .idle }
+                    }
                 Text(Copy.keychainNote)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -184,6 +197,43 @@ struct SettingsView: View {
 
             DisclosureGroup("Advanced") {
                 VStack(alignment: .leading, spacing: 10) {
+                    Picker("Cleaning style", selection: $coherenceMode) {
+                        Text("Fastest").tag("fast")
+                        Text("Balanced").tag("balanced")
+                        Text("Most careful").tag("max-coherence")
+                    }
+                    .onChange(of: coherenceMode) {
+                        guard engineOptionsLoaded else { return }
+                        Task { await applyEngineOptions() }
+                    }
+                    .help(
+                        "How much surrounding context each part of a document "
+                            + "gets while cleaning. Most careful reads strictly in "
+                            + "order; Fastest cleans parts in parallel."
+                    )
+                    Toggle("Describe charts and figures with AI", isOn: $figureVisionEnabled)
+                        .onChange(of: figureVisionEnabled) {
+                            guard engineOptionsLoaded else { return }
+                            Task { await applyEngineOptions() }
+                        }
+                        .help(
+                            "Adds a written description under each chart or figure "
+                                + "found in PDFs, using your AI provider. Costs extra "
+                                + "tokens per figure."
+                        )
+                    if figureVisionEnabled {
+                        TextField(
+                            "Vision model (blank = cleaning model)",
+                            text: $figureVisionModel,
+                            prompt: Text("optional")
+                        )
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+                        .onSubmit {
+                            Task { await applyEngineOptions() }
+                        }
+                    }
+                    Divider()
                     Toggle("Also keep original files in the destination", isOn: $keepOriginals)
                     Toggle("Use the built-in engine", isOn: $useEmbedded)
                         .onChange(of: useEmbedded) {
@@ -295,6 +345,10 @@ struct SettingsView: View {
 
     private func loadCurrent() {
         let values = EnvFile.read()
+        coherenceMode = values["LIBRARIAN_COHERENCE_MODE"] ?? "balanced"
+        figureVisionEnabled = values["LIBRARIAN_FIGURE_VISION_ENABLED"] == "true"
+        figureVisionModel = values["LIBRARIAN_FIGURE_VISION_MODEL"] ?? ""
+        engineOptionsLoaded = true
         guard values["LIBRARIAN_LLM_PROVIDER"] == "openai-compatible" else {
             resetForPresetChange()
             return
@@ -324,6 +378,33 @@ struct SettingsView: View {
             manualModel = current
             phase = .active(current)
         }
+    }
+
+    /// Persist the Advanced engine options and restart the engine so they
+    /// apply. Defaults are removed from the file rather than written, so a
+    /// hand-edited .env only carries deliberate overrides.
+    private func applyEngineOptions() async {
+        var updates: [String: String?] = [:]
+        updates.updateValue(
+            coherenceMode == "balanced" ? nil : coherenceMode,
+            forKey: "LIBRARIAN_COHERENCE_MODE"
+        )
+        updates.updateValue(
+            figureVisionEnabled ? "true" : nil,
+            forKey: "LIBRARIAN_FIGURE_VISION_ENABLED"
+        )
+        let visionModel = figureVisionModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        updates.updateValue(
+            (figureVisionEnabled && !visionModel.isEmpty) ? visionModel : nil,
+            forKey: "LIBRARIAN_FIGURE_VISION_MODEL"
+        )
+        do {
+            try EnvFile.update(updates)
+        } catch {
+            phase = .failed(error.localizedDescription)
+            return
+        }
+        await model.restartBackend()
     }
 
     private func connect() async {

--- a/apps/macos/Sources/Librarian/Views/ToolsView.swift
+++ b/apps/macos/Sources/Librarian/Views/ToolsView.swift
@@ -87,6 +87,13 @@ struct ToolsView: View {
                     }
                 }
                 .disabled(isRunning || !canRun)
+                if !BackendCLI.isAvailable {
+                    // Mirror DiagnosticsView: a silently disabled Run button
+                    // in unbundled (swift run) builds reads as broken.
+                    Text("File tools need the packaged app with a bundled backend.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
                 if let lastWrittenURL {
                     Button("Reveal Output in Finder") {
                         model.revealInFinder(lastWrittenURL)

--- a/apps/macos/Support/Info.plist
+++ b/apps/macos/Support/Info.plist
@@ -13,7 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<!-- Kept in sync with src/librarian/version.py at build time by the
+	     `app` target in the Makefile (which stamps the built app's plist).
+	     This static value is a fallback for plain `swift run`/manual builds. -->
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleIconFile</key>

--- a/apps/macos/scripts/bundle_backend.sh
+++ b/apps/macos/scripts/bundle_backend.sh
@@ -9,25 +9,48 @@ set -euo pipefail
 #
 # The wheel argument may also be a PyPI requirement such as
 # "nampara-librarian[all]==1.0.0".
+#
+# A --constraints file (e.g. the release constraints.txt exported from uv.lock)
+# is applied to pip so bundled dependency versions are pinned/reproducible.
 
 PBS_RELEASE="20260602"
 PYTHON_VERSION="3.12.13"
 
+# Expected SHA256 of the python-build-standalone tarball, per architecture, for
+# the pinned PBS_RELEASE + PYTHON_VERSION above. This is a supply-chain guard:
+# the download is verified against these digests and the build fails hard on any
+# mismatch (or if the digest is left unset).
+#
+# TODO(security): fill in the real digests before shipping. Obtain them from the
+# .sha256 sidecar files the PBS release publishes, e.g.:
+#   curl -fsSL "https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_RELEASE}/${TARBALL}.sha256"
+# (that file contains the hex digest for the matching TARBALL). Paste the 64-hex
+# value for each arch below. The literal placeholder string will never match a
+# real digest, so an unfilled value fails the build rather than skipping the
+# check.
+PBS_SHA256_aarch64="REPLACE_WITH_REAL_SHA256_FOR_aarch64"
+PBS_SHA256_x86_64="REPLACE_WITH_REAL_SHA256_FOR_x86_64"
+
 APP=""
 WHEEL=""
 ARCH="$(uname -m)"
+CONSTRAINTS=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --app) APP="$2"; shift 2 ;;
     --wheel) WHEEL="$2"; shift 2 ;;
     --arch) ARCH="$2"; shift 2 ;;
+    --constraints) CONSTRAINTS="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
 [[ -d "$APP" ]] || { echo "--app must point at an existing .app bundle" >&2; exit 1; }
 [[ -n "$WHEEL" ]] || { echo "--wheel is required (wheel path or PyPI requirement)" >&2; exit 1; }
+if [[ -n "$CONSTRAINTS" ]]; then
+  [[ -f "$CONSTRAINTS" ]] || { echo "--constraints file not found: $CONSTRAINTS" >&2; exit 1; }
+fi
 
 case "$ARCH" in
   arm64|aarch64) PBS_ARCH="aarch64" ;;
@@ -42,8 +65,25 @@ mkdir -p "$BACKEND_DIR"
 TARBALL="cpython-${PYTHON_VERSION}+${PBS_RELEASE}-${PBS_ARCH}-apple-darwin-install_only_stripped.tar.gz"
 URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_RELEASE}/${TARBALL}"
 
+# Select the expected digest for the target arch (indirect expansion).
+EXPECTED_SHA_VAR="PBS_SHA256_${PBS_ARCH}"
+EXPECTED_SHA="${!EXPECTED_SHA_VAR:-}"
+if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-fA-F]{64}$ ]]; then
+  echo "No valid pinned SHA256 for ${PBS_ARCH} (got '${EXPECTED_SHA}')." >&2
+  echo "Refusing to bundle an unverified Python runtime; fill in ${EXPECTED_SHA_VAR}." >&2
+  exit 1
+fi
+
 echo "Downloading ${TARBALL}"
 curl -fL --retry 3 --retry-delay 2 -o "${BACKEND_DIR}/python.tar.gz" "$URL"
+
+echo "Verifying tarball SHA256"
+# Verify against the pinned digest before extracting. shasum -c fails non-zero
+# on mismatch, and `set -e` aborts the build — nothing is extracted on failure.
+printf '%s  %s\n' "$EXPECTED_SHA" "${BACKEND_DIR}/python.tar.gz" \
+  | shasum -a 256 -c - \
+  || { echo "SHA256 mismatch for ${TARBALL}; aborting (possible tampering)." >&2; exit 1; }
+
 tar -xzf "${BACKEND_DIR}/python.tar.gz" -C "$BACKEND_DIR"
 rm "${BACKEND_DIR}/python.tar.gz"
 
@@ -59,13 +99,23 @@ PIP_BINARY=()
 if [[ "$PBS_ARCH" == "x86_64" && "$(uname -m)" == "arm64" ]]; then
   PIP_BINARY+=(--only-binary=:all:)
 fi
+# Apply the exported dependency constraints (exact pins from uv.lock) when
+# provided, so the bundled runtime's dependencies are reproducible and pinned
+# instead of resolving to whatever is latest on PyPI at build time.
+PIP_CONSTRAINTS=()
+if [[ -n "$CONSTRAINTS" ]]; then
+  echo "Applying dependency constraints: $CONSTRAINTS"
+  PIP_CONSTRAINTS+=(-c "$CONSTRAINTS")
+fi
 echo "Installing Librarian backend"
 if [[ -f "$WHEEL" ]]; then
   "$PYBIN" -m pip install --quiet --no-warn-script-location \
-    ${PIP_BINARY[@]+"${PIP_BINARY[@]}"} "${WHEEL}[all]"
+    ${PIP_BINARY[@]+"${PIP_BINARY[@]}"} \
+    ${PIP_CONSTRAINTS[@]+"${PIP_CONSTRAINTS[@]}"} "${WHEEL}[all]"
 else
   "$PYBIN" -m pip install --quiet --no-warn-script-location \
-    ${PIP_BINARY[@]+"${PIP_BINARY[@]}"} "$WHEEL"
+    ${PIP_BINARY[@]+"${PIP_BINARY[@]}"} \
+    ${PIP_CONSTRAINTS[@]+"${PIP_CONSTRAINTS[@]}"} "$WHEEL"
 fi
 
 "$PYBIN" -m librarian version >/dev/null

--- a/apps/macos/scripts/bundle_backend.sh
+++ b/apps/macos/scripts/bundle_backend.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # A --constraints file (e.g. the release constraints.txt exported from uv.lock)
 # is applied to pip so bundled dependency versions are pinned/reproducible.
 
-PBS_RELEASE="20260602"
+PBS_RELEASE="20260623"
 PYTHON_VERSION="3.12.13"
 
 # Expected SHA256 of the python-build-standalone tarball, per architecture, for
@@ -21,15 +21,14 @@ PYTHON_VERSION="3.12.13"
 # the download is verified against these digests and the build fails hard on any
 # mismatch (or if the digest is left unset).
 #
-# TODO(security): fill in the real digests before shipping. Obtain them from the
-# .sha256 sidecar files the PBS release publishes, e.g.:
-#   curl -fsSL "https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_RELEASE}/${TARBALL}.sha256"
-# (that file contains the hex digest for the matching TARBALL). Paste the 64-hex
-# value for each arch below. The literal placeholder string will never match a
-# real digest, so an unfilled value fails the build rather than skipping the
-# check.
-PBS_SHA256_aarch64="REPLACE_WITH_REAL_SHA256_FOR_aarch64"
-PBS_SHA256_x86_64="REPLACE_WITH_REAL_SHA256_FOR_x86_64"
+# Provenance: these digests were cross-verified against two independent
+# sources — the SHA256 GitHub displays per asset on the release page
+# (https://github.com/astral-sh/python-build-standalone/releases/tag/20260623)
+# and the digest table vendored in uv 0.11.26 — which agreed exactly.
+# When bumping PBS_RELEASE/PYTHON_VERSION, re-verify the new digests the same
+# way; a stale or mistyped value fails the build rather than skipping the check.
+PBS_SHA256_aarch64="41df7d3ae4757e84b97874f76d634268456aaa271740d33f968d826374998fb7"
+PBS_SHA256_x86_64="a6bbea996c5f14eb55ab275889d2df45408deec504b4a7219d7b59c045b2555e"
 
 APP=""
 WHEEL=""

--- a/apps/macos/scripts/bundle_ocr.sh
+++ b/apps/macos/scripts/bundle_ocr.sh
@@ -115,9 +115,20 @@ ${RUN[@]+"${RUN[@]}"} "$DYLIBBUNDLER" -of -b -cd \
 echo "Verifying no Homebrew paths leak into the bundled OCR tools"
 leaked=0
 while IFS= read -r -d '' macho; do
+  # (1) Dependent library load paths (LC_LOAD_DYLIB): must not point at Homebrew.
   if otool -L "$macho" | tail -n +2 | grep -E "/opt/homebrew/|/usr/local/(Cellar|opt|lib)" >/dev/null; then
     echo "Leaked Homebrew path in: $macho" >&2
     otool -L "$macho" | grep -E "/opt/homebrew/|/usr/local/" >&2 || true
+    leaked=1
+  fi
+  # (2) Runtime search paths (LC_RPATH): dylibbundler rewrites @rpath deps to
+  # @executable_path/../lib, but a leftover LC_RPATH pointing at Homebrew would
+  # still let @rpath-based lookups resolve against a developer's machine (and
+  # fail — or worse, load an unexpected dylib — on end-user machines). Fail hard
+  # if any Homebrew rpath survives.
+  if otool -l "$macho" | grep -A2 LC_RPATH | grep -E "/opt/homebrew|/usr/local" >/dev/null; then
+    echo "Leaked Homebrew LC_RPATH in: $macho" >&2
+    otool -l "$macho" | grep -A2 LC_RPATH | grep -E "/opt/homebrew|/usr/local" >&2 || true
     leaked=1
   fi
 done < <(find "$BIN_DIR" "$LIB_DIR" -type f -print0)

--- a/apps/macos/scripts/sign_app.sh
+++ b/apps/macos/scripts/sign_app.sh
@@ -24,10 +24,40 @@ done
 
 [[ -d "$APP" ]] || { echo "--app must point at an existing .app bundle" >&2; exit 1; }
 
-SIGN_FLAGS=(--force --sign "$IDENTITY")
+# Entitlement scoping (least privilege):
+#   - The broad entitlements in Support/entitlements.plist
+#     (disable-library-validation + allow-unsigned-executable-memory) are needed
+#     ONLY by the embedded CPython interpreter: it loads unsigned/third-party
+#     C-extension .so files (library validation) and some deps JIT/allocate
+#     executable memory. Applying them to every nested binary — including the
+#     bundled OCR tools (tesseract/pdftoppm/...) — needlessly widens the attack
+#     surface.
+#   - Every Mach-O still gets the hardened runtime (--options runtime) for
+#     notarization; the OCR tools are signed WITHOUT the broad entitlements.
+#
+# Always apply --options runtime so the hardened runtime is consistent across
+# ad-hoc and Developer ID signing. Entitlements/timestamp only apply for a real
+# Developer ID identity (ad-hoc "-" signing cannot carry them meaningfully).
+
+# Base flags for every binary: hardened runtime, no broad entitlements.
+BASE_FLAGS=(--force --sign "$IDENTITY" --options runtime)
+# Flags for the Python interpreter: base + the broad entitlements.
+PY_FLAGS=(--force --sign "$IDENTITY" --options runtime)
 if [[ "$IDENTITY" != "-" ]]; then
-  SIGN_FLAGS+=(--options runtime --timestamp --entitlements "$ENTITLEMENTS")
+  BASE_FLAGS+=(--timestamp)
+  PY_FLAGS+=(--timestamp --entitlements "$ENTITLEMENTS")
 fi
+
+# The interpreter binaries that legitimately need the broad entitlements. These
+# live under Contents/Resources/backend/python/bin (python3, python3.x). Match
+# by realpath so the symlink and the real binary both get the entitlements.
+is_python_interpreter() {
+  local path="$1"
+  case "$path" in
+    */Resources/backend/python/bin/python*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 # Sign nested Mach-O files first (the embedded Python and its extensions, plus
 # the bundled OCR tools and their relocated dylibs), then the app bundle
@@ -37,11 +67,18 @@ for nested in backend ocr; do
   [[ -d "$dir" ]] || continue
   while IFS= read -r -d '' binary; do
     if file -b "$binary" | grep -q "Mach-O"; then
-      codesign "${SIGN_FLAGS[@]}" "$binary"
+      if is_python_interpreter "$binary"; then
+        codesign "${PY_FLAGS[@]}" "$binary"
+      else
+        codesign "${BASE_FLAGS[@]}" "$binary"
+      fi
     fi
   done < <(find "$dir" -type f \( -perm -111 -o -name "*.so" -o -name "*.dylib" \) -print0)
 done
 
-codesign "${SIGN_FLAGS[@]}" "$APP"
+# Sign the app bundle itself with the interpreter entitlements: the app's main
+# executable launches the embedded interpreter, and the top-level entitlements
+# govern the process. Nested OCR tools were already signed WITHOUT them above.
+codesign "${PY_FLAGS[@]}" "$APP"
 codesign --verify --deep --strict "$APP"
 echo "Signed $APP with identity: $IDENTITY"

--- a/docs/API.md
+++ b/docs/API.md
@@ -144,7 +144,8 @@ validated before conversion starts and must not be symlinks or cross symlinked p
   the active result set. `facet_limit` caps classification and filename bucket counts, defaults to
   `50`, and is capped at `500`; source totals still report the full matching document count.
 - `GET /classifications`: built-in Dewey labels.
-- `GET /config`: selected runtime settings.
+- `GET /config`: the effective runtime settings — LLM, chunking, extraction engine and cache,
+  token ceilings, figure vision, OCR, API limits, server bind — everything except secrets.
 - `GET /health`: health check.
 - `GET /ready`: readiness check that verifies the runtime data directory is writable, plus SQLite
   integrity and migration metadata.

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -46,7 +46,11 @@ from librarian.application.export_okf import (
     build_bundle,
     collect_sources,
 )
-from librarian.application.factory import build_container, build_ingest_container
+from librarian.application.factory import (
+    build_container,
+    build_ingest_container,
+    cache_wrap_extractor,
+)
 from librarian.application.import_library import ImportLibrary, ImportProcessingMode
 from librarian.application.jobs import InProcessJobRunner
 from librarian.application.ports import SearchScope
@@ -1329,7 +1333,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
         )
         importer = ImportLibrary(
-            converter=DocumentConverter(extractor, metrics),
+            converter=DocumentConverter(
+                cache_wrap_extractor(
+                    extractor, settings=settings, cache_store=container.repository
+                ),
+                metrics,
+            ),
             ingest=container.ingest_document,
             process=getattr(container, "process_document", None),
             queue_factory=lambda: SQLiteRunQueue(container.database),

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -79,7 +79,12 @@ from librarian.observability import (
     sanitize_error_message,
     start_request_span,
 )
-from librarian.storage.sqlite import SQLiteDatabase, SQLiteRunQueue, normalize_search_query
+from librarian.storage.sqlite import (
+    SQLiteDatabase,
+    SQLiteRepository,
+    SQLiteRunQueue,
+    normalize_search_query,
+)
 from librarian.taxonomy.dewey import DeweyTaxonomy
 from librarian.version import __version__
 
@@ -702,7 +707,19 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-        await SQLiteDatabase(settings.database_path).initialize()
+        database = SQLiteDatabase(settings.database_path)
+        await database.initialize()
+        # An in-process run has no durable lease, so any run still marked RUNNING
+        # at startup was orphaned by a previous crash/restart. Reconcile it to
+        # FAILED so it doesn't appear active forever and can be retried.
+        if settings.job_backend == "in-process":
+            reconciled = await SQLiteRepository(database).fail_interrupted_runs(
+                error="interrupted by server restart"
+            )
+            if reconciled:
+                logging.getLogger("librarian.api").warning(
+                    "reconciled %d interrupted run(s) on startup", reconciled
+                )
         runner = InProcessJobRunner(max_concurrency=settings.job_max_concurrency)
         app.state.job_runner = runner
         app.state.settings = settings

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -461,6 +461,31 @@ class ConfigResponse(BaseModel):
     ocr_fail_on_page_error: bool
     universal_max_input_bytes: int
     universal_timeout_seconds: int
+    # Extraction engine / cache.
+    pdf_engine: str
+    liteparse_dpi: int
+    liteparse_image_mode: str
+    liteparse_ocr_server_url: str | None
+    liteparse_tessdata_path: str | None
+    ocr_auto_orient: bool
+    extraction_cache_enabled: bool
+    extraction_timeout_seconds: int
+    import_concurrency: int
+    # Token ceilings.
+    llm_max_output_tokens: int
+    classification_max_output_tokens: int
+    # Figure vision.
+    figure_vision_enabled: bool
+    figure_vision_model: str | None
+    figure_vision_max_figures: int
+    figure_vision_min_bytes: int
+    figure_vision_max_bytes: int
+    figure_vision_max_concurrency: int
+    figure_vision_max_response_chars: int
+    # Server bind + storage.
+    api_host: str
+    api_port: int
+    database_path: str
     log_level: str
     log_format: str
     metrics_enabled: bool
@@ -1787,6 +1812,27 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             ocr_fail_on_page_error=settings.ocr_fail_on_page_error,
             universal_max_input_bytes=settings.universal_max_input_bytes,
             universal_timeout_seconds=settings.universal_timeout_seconds,
+            pdf_engine=settings.pdf_engine,
+            liteparse_dpi=settings.liteparse_dpi,
+            liteparse_image_mode=settings.liteparse_image_mode,
+            liteparse_ocr_server_url=settings.liteparse_ocr_server_url,
+            liteparse_tessdata_path=settings.liteparse_tessdata_path,
+            ocr_auto_orient=settings.ocr_auto_orient,
+            extraction_cache_enabled=settings.extraction_cache_enabled,
+            extraction_timeout_seconds=settings.extraction_timeout_seconds,
+            import_concurrency=settings.import_concurrency,
+            llm_max_output_tokens=settings.llm_max_output_tokens,
+            classification_max_output_tokens=settings.classification_max_output_tokens,
+            figure_vision_enabled=settings.figure_vision_enabled,
+            figure_vision_model=settings.figure_vision_model,
+            figure_vision_max_figures=settings.figure_vision_max_figures,
+            figure_vision_min_bytes=settings.figure_vision_min_bytes,
+            figure_vision_max_bytes=settings.figure_vision_max_bytes,
+            figure_vision_max_concurrency=settings.figure_vision_max_concurrency,
+            figure_vision_max_response_chars=settings.figure_vision_max_response_chars,
+            api_host=settings.api_host,
+            api_port=settings.api_port,
+            database_path=str(settings.database_path),
             log_level=settings.log_level,
             log_format=settings.log_format,
             metrics_enabled=settings.metrics_enabled,

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -2737,10 +2737,19 @@ def _rate_limit_identity(request: Request, settings: Settings) -> str:
 def _client_host(request: Request, settings: Settings) -> str:
     client_host = request.client.host if request.client else "unknown"
     forwarded_for = request.headers.get("x-forwarded-for")
-    if forwarded_for and _trusted_proxy_client_host(client_host, settings):
-        forwarded_host = forwarded_for.split(",", maxsplit=1)[0].strip()
-        if _valid_forwarded_ip(forwarded_host):
-            client_host = forwarded_host
+    if not forwarded_for or not _trusted_proxy_client_host(client_host, settings):
+        return client_host
+    # Walk the chain from the right: the rightmost entry was appended by our own
+    # trusted proxy and is the hardest to spoof, whereas the leftmost is fully
+    # client-controlled. Skip successive trusted-proxy hops until the first
+    # address that is not a trusted proxy -- that is the real client.
+    hops = [hop.strip() for hop in forwarded_for.split(",") if hop.strip()]
+    for candidate in reversed(hops):
+        if not _valid_forwarded_ip(candidate):
+            continue
+        if _trusted_proxy_client_host(candidate, settings):
+            continue
+        return candidate
     return client_host
 
 

--- a/src/librarian/api/app.py
+++ b/src/librarian/api/app.py
@@ -12,7 +12,7 @@ import sqlite3
 import tempfile
 import time
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -2824,35 +2824,85 @@ def _job_runner(request: Request) -> InProcessJobRunner:
     return runner
 
 
-async def _event_stream(settings: Settings, run_id: RunId) -> AsyncIterator[str]:
+_TERMINAL_RUN_STATUSES = frozenset(
+    {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.CANCELED}
+)
+_EVENT_STREAM_PAGE = 500
+
+
+def _sse_data_frame(text: str) -> str:
+    """Render an SSE ``data:`` frame, splitting embedded newlines.
+
+    A raw newline inside a ``data:`` payload terminates the SSE event early,
+    so each line is emitted as its own ``data:`` field per the spec.
+    """
+    body = "\n".join(f"data: {line}" for line in text.split("\n"))
+    return f"{body}\n\n"
+
+
+async def _stream_run_events(
+    settings: Settings,
+    run_id: RunId,
+    fetch_frames: Callable[[Any, int], Awaitable[list[str]]],
+) -> AsyncIterator[str]:
+    """Poll and stream a run's events as SSE frames until the run is terminal.
+
+    The container is built once (not per poll), a full page triggers an
+    immediate re-read (no artificial 200ms delay while backlogged), and when
+    the run reaches a terminal status the loop drains any remaining events
+    before signaling ``done``. The final "processing failed/complete" event is
+    emitted *after* the terminal status is written, so the drain is what keeps
+    it from being lost.
+    """
+    container = await build_ingest_container(settings)
     seen = 0
     while True:
-        container = await build_ingest_container(settings)
-        events = list(await container.repository.list_events(run_id, limit=500, offset=seen))
-        for event in events:
-            yield f"data: {event}\n\n"
-        seen += len(events)
+        frames = await fetch_frames(container, seen)
+        for frame in frames:
+            yield frame
+        seen += len(frames)
+        if len(frames) == _EVENT_STREAM_PAGE:
+            continue
         run = await container.repository.get_run(run_id)
-        if run is None or run.status in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.CANCELED}:
+        if run is None or run.status in _TERMINAL_RUN_STATUSES:
+            while True:
+                tail = await fetch_frames(container, seen)
+                if not tail:
+                    break
+                for frame in tail:
+                    yield frame
+                seen += len(tail)
             yield "event: done\ndata: done\n\n"
-            break
+            return
         await asyncio.sleep(0.2)
+
+
+async def _event_stream(settings: Settings, run_id: RunId) -> AsyncIterator[str]:
+    async def fetch_frames(container: Any, offset: int) -> list[str]:
+        events = await container.repository.list_events(
+            run_id, limit=_EVENT_STREAM_PAGE, offset=offset
+        )
+        return [_sse_data_frame(event) for event in events]
+
+    async for frame in _stream_run_events(settings, run_id, fetch_frames):
+        yield frame
 
 
 async def _event_record_stream(settings: Settings, run_id: RunId) -> AsyncIterator[str]:
-    seen = 0
-    while True:
-        container = await build_ingest_container(settings)
-        events = list(await container.repository.list_event_records(run_id, limit=500, offset=seen))
+    async def fetch_frames(container: Any, offset: int) -> list[str]:
+        events = await container.repository.list_event_records(
+            run_id, limit=_EVENT_STREAM_PAGE, offset=offset
+        )
+        frames: list[str] = []
         for event in events:
             payload = _run_event_response(event).model_dump()
-            yield f"event: run-event\ndata: {json.dumps(payload, separators=(',', ':'))}\n\n"
-        seen += len(events)
-        run = await container.repository.get_run(run_id)
-        if run is None or run.status in {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.CANCELED}:
-            yield "event: done\ndata: done\n\n"
-            break
-        await asyncio.sleep(0.2)
+            frames.append(
+                f"event: run-event\ndata: {json.dumps(payload, separators=(',', ':'))}\n\n"
+            )
+        return frames
+
+    async for frame in _stream_run_events(settings, run_id, fetch_frames):
+        yield frame
 
 
 def _normalize_export_format(format: str) -> ExportFormat:

--- a/src/librarian/application/classify_document.py
+++ b/src/librarian/application/classify_document.py
@@ -174,8 +174,11 @@ def _series_key(
     falls back to a period-stripped filename stem, but only when that stem is
     distinctive enough to be a real series rather than a generic name.
     """
-    primary = " ".join(part for part in (issuer, series_title) if part and part.strip())
-    if primary.strip():
+    # A series identity requires an actual recurring-publication *title*. An
+    # issuer alone is not a series (otherwise every one-off document from the
+    # same publisher would be falsely linked as editions of one series).
+    if series_title and series_title.strip():
+        primary = " ".join(part for part in (issuer, series_title) if part and part.strip())
         return _series_slug(primary) or None
     if fallback_filename:
         stem = (
@@ -226,7 +229,7 @@ class ClassifyDocument:
     prompt_version: str
     model: str
     taxonomy: TaxonomyProvider
-    max_tokens: int = 500
+    max_tokens: int = 2_048
     temperature: float = 0.0
     max_response_chars: int = 2 * 1024 * 1024
 

--- a/src/librarian/application/classify_document.py
+++ b/src/librarian/application/classify_document.py
@@ -111,6 +111,24 @@ _GENERIC_SERIES_STEMS = frozenset(
 )
 
 
+def _classification_sample(text: str, *, budget: int) -> str:
+    """Return a representative excerpt of the document for classification.
+
+    Short documents are used whole. For longer ones, sampling only the head
+    means a title page or table of contents decides the classification; taking
+    head + middle + tail gives the model a view of the actual body too, within
+    the same character budget.
+    """
+    if budget <= 0 or len(text) <= budget:
+        return text
+    segment = max(1, budget // 3)
+    head = text[:segment]
+    middle_start = max(segment, (len(text) - segment) // 2)
+    middle = text[middle_start : middle_start + segment]
+    tail = text[len(text) - segment :]
+    return "\n[...]\n".join((head, middle, tail))
+
+
 def _clean_one_line(value: str | None, *, max_chars: int) -> str | None:
     if value is None:
         return None
@@ -232,6 +250,7 @@ class ClassifyDocument:
     max_tokens: int = 2_048
     temperature: float = 0.0
     max_response_chars: int = 2 * 1024 * 1024
+    sample_chars: int = 8_000
 
     async def execute(
         self,
@@ -241,7 +260,7 @@ class ClassifyDocument:
         source_filename: str | None = None,
     ) -> Classification:
         prompt = self.prompt_catalog.get("classification", self.prompt_version)
-        sample = text[:8_000]
+        sample = _classification_sample(text, budget=self.sample_chars)
         raw = await self.provider.complete(
             system_prompt=(
                 "You are a librarian expert in Dewey Decimal Classification. "

--- a/src/librarian/application/clean_chunks.py
+++ b/src/librarian/application/clean_chunks.py
@@ -38,6 +38,10 @@ class CleanChunks:
     max_parallel_chunks: int = 8
     balanced_group_size: int = 4
     max_response_chars: int = 2 * 1024 * 1024
+    # Trailing characters of the preceding chunk handed to the cleaner as
+    # read-only continuity context. Chunks no longer overlap in the source, so
+    # this replaces the (previously duplicated) overlap for boundary coherence.
+    context_chars: int = 800
 
     async def execute(
         self,
@@ -75,9 +79,16 @@ class CleanChunks:
                 except asyncio.QueueEmpty:
                     return
                 try:
-                    results[positions[chunk.id]] = await self._clean_one(
+                    # Unordered mode: give each chunk the raw tail of its
+                    # predecessor as context so a boundary-split fragment still
+                    # cleans coherently (context is read-only, never re-emitted).
+                    index = positions[chunk.id]
+                    previous_context = (
+                        chunks[index - 1].text[-self.context_chars :] if index > 0 else ""
+                    )
+                    results[index] = await self._clean_one(
                         chunk,
-                        previous_context="",
+                        previous_context=previous_context,
                     )
                     if on_chunk_cleaned is not None:
                         await on_chunk_cleaned()
@@ -132,7 +143,7 @@ class CleanChunks:
         for chunk in chunks:
             result = await self._clean_one(chunk, previous_context=previous_context)
             results.append(result)
-            previous_context = result.text[-500:]
+            previous_context = result.text[-self.context_chars :]
             if on_chunk_cleaned is not None:
                 await on_chunk_cleaned()
         return results

--- a/src/librarian/application/clean_chunks.py
+++ b/src/librarian/application/clean_chunks.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from librarian.application.ports import LLMProvider
 from librarian.domain.models import Chunk
@@ -13,6 +13,45 @@ from librarian.pipeline.validation import validate_cleaned_text
 from librarian.prompts.loader import PromptCatalog
 
 CoherenceMode = Literal["fast", "balanced", "max-coherence"]
+
+
+async def _run_workers(
+    worker: Callable[[], Coroutine[Any, Any, None]],
+    worker_count: int,
+) -> None:
+    """Run N identical workers, cancelling the rest on the first failure.
+
+    ``asyncio.gather`` propagates the first exception but leaves sibling
+    workers running, orphaning their in-flight LLM calls (wasted cost and
+    late progress callbacks). This cancels the remaining workers as soon as
+    one fails and re-raises the original exception unwrapped, so upstream
+    ``except ValueError`` / ``except ProcessingCanceled`` handlers still match
+    (unlike ``asyncio.TaskGroup``, which wraps failures in an ExceptionGroup).
+    """
+    tasks: list[asyncio.Task[None]] = [
+        asyncio.create_task(worker()) for _ in range(worker_count)
+    ]
+    try:
+        await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+    except asyncio.CancelledError:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+    first_error: BaseException | None = None
+    for task in tasks:
+        if task.cancelled() or not task.done():
+            continue
+        exc = task.exception()
+        if exc is not None:
+            first_error = exc
+            break
+    if first_error is not None:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise first_error
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,7 +134,7 @@ class CleanChunks:
                 finally:
                     queue.task_done()
 
-        await asyncio.gather(*(worker() for _ in range(worker_count)))
+        await _run_workers(worker, worker_count)
         return [item for item in results if item is not None]
 
     async def _clean_balanced(
@@ -126,7 +165,7 @@ class CleanChunks:
                 finally:
                     queue.task_done()
 
-        await asyncio.gather(*(worker() for _ in range(worker_count)))
+        await _run_workers(worker, worker_count)
         results: list[CleanedChunk] = []
         for group in group_results:
             if group is not None:

--- a/src/librarian/application/convert_document.py
+++ b/src/librarian/application/convert_document.py
@@ -183,6 +183,10 @@ class DocumentConverter:
         page_manifest_path = output_path.with_suffix(f"{output_path.suffix}.pages.json")
         set_page_manifest_path = getattr(self.extractor, "set_page_manifest_path", None)
         if callable(set_page_manifest_path):
+            # Every convert_file call sets this explicitly (path or None), so the
+            # value never leaks in from a prior extraction. Concurrent conversions
+            # run in separate asyncio task contexts, so the underlying ContextVar
+            # stays isolated per-conversion.
             set_page_manifest_path(page_manifest_path if write_sidecar else None)
         text = await self.extractor.extract(source_path)
         # Capture the extractor's per-run metadata immediately, before any further

--- a/src/librarian/application/factory.py
+++ b/src/librarian/application/factory.py
@@ -133,9 +133,11 @@ async def build_container(
         prompt_catalog=PromptCatalog(),
         prompt_version=resolved_settings.cleaning_prompt_version,
         model=resolved_settings.llm_model,
+        max_tokens=resolved_settings.llm_max_output_tokens,
         coherence_mode=resolved_settings.coherence_mode,
         max_parallel_chunks=resolved_settings.llm_max_concurrency,
         max_response_chars=resolved_settings.llm_max_response_chars,
+        context_chars=resolved_settings.chunk_overlap_chars,
     )
     taxonomy = ingest_container.taxonomy
     classifier = ClassifyDocument(
@@ -144,6 +146,7 @@ async def build_container(
         prompt_version=resolved_settings.classification_prompt_version,
         model=resolved_settings.llm_model,
         taxonomy=taxonomy,
+        max_tokens=resolved_settings.classification_max_output_tokens,
         max_response_chars=resolved_settings.llm_max_response_chars,
     )
     policy = ChunkingPolicy(

--- a/src/librarian/application/factory.py
+++ b/src/librarian/application/factory.py
@@ -12,7 +12,11 @@ from librarian.application.ports import ApplicationMetrics, LLMProvider
 from librarian.application.process_document import ProcessDocument
 from librarian.application.search_library import SearchLibrary
 from librarian.config import Settings
-from librarian.ingest.extractors import CachingExtractor, CompositeExtractor
+from librarian.ingest.extractors import (
+    CachingExtractor,
+    CompositeExtractor,
+    ExtractionCacheStore,
+)
 from librarian.llm import LazyLLMProvider, build_provider
 from librarian.observability import NoOpMetricsRecorder
 from librarian.pipeline.chunking import ChunkingPolicy
@@ -175,6 +179,24 @@ async def build_container(
         taxonomy=ingest_container.taxonomy,
         process_document=process,
     )
+
+
+def cache_wrap_extractor(
+    extractor: CompositeExtractor,
+    *,
+    settings: Settings,
+    cache_store: ExtractionCacheStore,
+) -> CompositeExtractor | CachingExtractor:
+    """Wrap an extractor with the content-hash cache when enabled.
+
+    Used so the convert/import paths (not just direct ingest) benefit from the
+    extraction cache — re-importing unchanged files then skips re-extraction.
+    """
+    if settings.extraction_cache_enabled:
+        return CachingExtractor(
+            extractor, cache_store, config_signature=extractor.config_signature
+        )
+    return extractor
 
 
 def _build_provider(

--- a/src/librarian/application/ingest_document.py
+++ b/src/librarian/application/ingest_document.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import mimetypes
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 from librarian.application.ports import ContentStore, DocumentRepository, TextExtractor
 from librarian.domain.ids import DocumentId
@@ -55,8 +57,16 @@ class IngestDocument:
             ),
         )
         raw_text = await self.extractor.extract(source_path)
-        await self.documents.save_document(document)
-        await self.content.put_text(raw_text_key(document_id), raw_text)
+        # Persist the document row and its raw text atomically when the backend
+        # supports it, so a crash can't leave a document with no extractable text
+        # (which would fail processing with a KeyError).
+        save_atomic = getattr(self.documents, "save_document_with_content", None)
+        if callable(save_atomic):
+            save_atomic = cast("Callable[..., Awaitable[None]]", save_atomic)
+            await save_atomic(document, raw_text_key(document_id), raw_text)
+        else:
+            await self.documents.save_document(document)
+            await self.content.put_text(raw_text_key(document_id), raw_text)
         return IngestedDocument(document=document, raw_text=raw_text)
 
 

--- a/src/librarian/application/jobs.py
+++ b/src/librarian/application/jobs.py
@@ -203,9 +203,22 @@ class QueueWorker:
         return True
 
     async def run_forever(self) -> None:
-        """Poll the queue until stopped."""
+        """Poll the queue until stopped.
+
+        A transient failure in claim/process/fail must not tear the worker
+        loop down permanently: log it, back off, and keep polling. Only an
+        explicit cancellation stops the loop.
+        """
         while not self._stopping:
-            did_work = await self.run_once()
+            try:
+                did_work = await self.run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - keep the worker alive across transient errors
+                self.metrics.record_queue_failure()
+                logging.getLogger("librarian.jobs").exception("queue_worker_run_once_failed")
+                await asyncio.sleep(self.poll_interval_seconds)
+                continue
             if not did_work:
                 await asyncio.sleep(self.poll_interval_seconds)
 

--- a/src/librarian/application/process_document.py
+++ b/src/librarian/application/process_document.py
@@ -174,8 +174,11 @@ class ProcessDocument:
                     missing_chunks, on_chunk_cleaned=_note_chunk_cleaned
                 )
                 await self._raise_if_canceled(run_id)
+                # Never cache an empty/blank cleaning result: doing so would
+                # permanently rehydrate lost content on every future re-run.
+                cacheable = [chunk for chunk in cleaned_missing if chunk.text.strip()]
                 await self.outputs.save_cleaned_chunk_cache(
-                    cleaned_missing,
+                    cacheable,
                     prompt_version=self.cleaner.prompt_version,
                     model_provider=self.cleaner.provider.name,
                     model_name=self.cleaner.model,
@@ -215,6 +218,14 @@ class ProcessDocument:
                     stage=RunStage.ASSEMBLE,
                 )
                 assembled = assemble_cleaned_document(cleaned_chunks)
+            # Guard against publishing an empty document as a success: if every
+            # chunk cleaned to nothing (truncation, refusal, provider outage),
+            # fail loudly instead of silently shipping a blank output.
+            if chunked and not assembled.strip():
+                raise ValueError(
+                    "cleaning produced no output for a non-empty document "
+                    f"({len(chunked)} chunk(s) all blank) — refusing to publish empty result"
+                )
             await self._raise_if_canceled(run_id)
             output = CleanedOutput(
                 document_id=document_id,

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -168,13 +168,27 @@ def db_maintain(
         bool,
         typer.Option(help="Also run VACUUM after checkpoint/optimize."),
     ] = False,
+    prune_cache_days: Annotated[
+        int | None,
+        typer.Option(
+            "--prune-cache-days",
+            help="Delete extraction/cleaned-chunk cache rows older than N days.",
+            min=0,
+        ),
+    ] = None,
 ) -> None:
-    """Run SQLite optimize, WAL checkpoint, and optional vacuum maintenance."""
+    """Run SQLite optimize, WAL checkpoint, optional cache prune, and vacuum."""
     settings = Settings()
 
     async def run() -> None:
         database = SQLiteDatabase(settings.database_path)
         await database.initialize()
+        if prune_cache_days is not None:
+            pruned = await database.prune_caches(older_than_days=prune_cache_days)
+            console.print(
+                "Pruned cache rows: "
+                + ", ".join(f"{table}={count}" for table, count in sorted(pruned.items()))
+            )
         result = await database.maintain(vacuum=vacuum)
         console.print(
             "SQLite maintenance complete: "

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -187,6 +187,25 @@ def db_maintain(
     asyncio.run(run())
 
 
+@admin_app.command("config")
+def admin_config(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print machine-readable JSON."),
+    ] = False,
+) -> None:
+    """Show the effective runtime configuration (secrets redacted)."""
+    settings = Settings()
+    payload = settings.redacted_config()
+    if json_output:
+        console.out(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    table = Table("Setting", "Value")
+    for name, value in sorted(payload.items()):
+        table.add_row(name, "" if value is None else str(value))
+    console.print(table)
+
+
 @admin_app.command("db-check")
 def db_check() -> None:
     """Verify SQLite integrity, foreign keys, and migrations."""

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -58,6 +58,7 @@ from librarian.ingest.extractors import CompositeExtractor
 from librarian.llm import LazyLLMProvider
 from librarian.observability import sanitize_error_message
 from librarian.pipeline.chunking import ChunkingPolicy, chunk_text
+from librarian.runtime.parent_watch import start_parent_death_watcher
 from librarian.storage.sqlite import SQLiteDatabase, SQLiteRunQueue
 from librarian.version import __version__
 
@@ -1918,6 +1919,9 @@ def api(
             )
         if settings.api_import_root is None:
             raise typer.BadParameter("LIBRARIAN_API_IMPORT_ROOT is required when binding publicly")
+    # When launched by a desktop app (which passes LIBRARIAN_PARENT_PID), exit if
+    # that parent dies so the backend never lingers as an orphan on the port.
+    start_parent_death_watcher()
     uvicorn.run(
         "librarian.api.app:create_app",
         factory=True,

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -78,8 +78,16 @@ _MAX_PAGE_MANIFEST_READ_BYTES = 256 * 1024 * 1024
 
 
 @app.command()
-def version() -> None:
+def version(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print machine-readable version info."),
+    ] = False,
+) -> None:
     """Print the Librarian version."""
+    if json_output:
+        console.out(json.dumps({"version": __version__}))
+        return
     console.print(__version__)
 
 
@@ -595,12 +603,17 @@ def convert_dir(
     ] = "librarian-converted",
     recursive: Annotated[bool, typer.Option(help="Recurse into child directories.")] = False,
     overwrite: Annotated[bool, typer.Option(help="Overwrite existing outputs.")] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print the machine-readable conversion report to stdout."),
+    ] = False,
     sidecar_metadata: Annotated[
         bool,
         typer.Option(help="Deprecated; batch conversion always writes provenance sidecars."),
     ] = False,
 ) -> None:
     """Batch convert supported files in a directory."""
+    del sidecar_metadata
     conversion_format = _conversion_format(format)
     mode = _directory_output_mode(output_mode)
     try:
@@ -629,20 +642,26 @@ def convert_dir(
             subdirectory_name=subdirectory_name,
             recursive=recursive,
             overwrite=overwrite,
-            write_sidecar=sidecar_metadata,
+            # Sidecars mark outputs as librarian artifacts so re-runs skip
+            # them; the deprecated flag is ignored to match import behavior
+            # (and the flag's own help text).
+            write_sidecar=True,
         )
-        table = Table("Status", "Source", "Output", "Error")
-        for item in result.items:
-            table.add_row(
-                item.status,
-                str(item.source_path),
-                str(item.output_path) if item.output_path else "",
-                item.error or "",
+        if json_output:
+            console.out(json.dumps(result.to_json_dict(), indent=2))
+        else:
+            table = Table("Status", "Source", "Output", "Error")
+            for item in result.items:
+                table.add_row(
+                    item.status,
+                    str(item.source_path),
+                    str(item.output_path) if item.output_path else "",
+                    item.error or "",
+                )
+            console.print(table)
+            console.print(
+                f"Converted {result.converted}, skipped {result.skipped}, failed {result.failed}"
             )
-        console.print(table)
-        console.print(
-            f"Converted {result.converted}, skipped {result.skipped}, failed {result.failed}"
-        )
         if result.failed:
             raise typer.Exit(code=1)
 
@@ -754,6 +773,10 @@ def import_directory(
     ] = None,
     resume: Annotated[bool, typer.Option(help="Resume from an existing manifest.")] = False,
     report: Annotated[Path | None, typer.Option(help="Write final JSON report.")] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print the machine-readable import report to stdout."),
+    ] = False,
     sidecar_metadata: Annotated[
         bool,
         typer.Option(help="Deprecated; batch import always writes provenance sidecars."),
@@ -827,22 +850,25 @@ def import_directory(
                 await write_import_report(report.expanduser(), result)
             except ValueError as exc:
                 raise typer.BadParameter(sanitize_error_message(exc)) from exc
-        table = Table("Status", "Source", "Converted", "Document", "Run", "Error")
-        for item in result.items:
-            table.add_row(
-                item.status,
-                str(item.source_path),
-                str(item.converted_path) if item.converted_path else "",
-                str(item.document_id) if item.document_id else "",
-                str(item.run_id) if item.run_id else "",
-                item.error or "",
+        if json_output:
+            console.out(json.dumps(result.to_json_dict(), indent=2))
+        else:
+            table = Table("Status", "Source", "Converted", "Document", "Run", "Error")
+            for item in result.items:
+                table.add_row(
+                    item.status,
+                    str(item.source_path),
+                    str(item.converted_path) if item.converted_path else "",
+                    str(item.document_id) if item.document_id else "",
+                    str(item.run_id) if item.run_id else "",
+                    item.error or "",
+                )
+            console.print(table)
+            console.print(
+                "Converted "
+                f"{result.converted}, ingested {result.ingested}, processed {result.processed}, "
+                f"queued {result.queued}, skipped {result.skipped}, failed {result.failed}"
             )
-        console.print(table)
-        console.print(
-            "Converted "
-            f"{result.converted}, ingested {result.ingested}, processed {result.processed}, "
-            f"queued {result.queued}, skipped {result.skipped}, failed {result.failed}"
-        )
         if result.failed:
             raise typer.Exit(code=1)
 
@@ -853,12 +879,34 @@ def import_directory(
 def list_runs(
     limit: Annotated[int, typer.Option(help="Maximum runs.", min=1, max=500)] = 100,
     offset: Annotated[int, typer.Option(help="Runs to skip.", min=0)] = 0,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print machine-readable run records."),
+    ] = False,
 ) -> None:
     """List processing runs."""
 
     async def run() -> None:
         container = await build_ingest_container()
         runs = await container.repository.list_runs(limit=limit, offset=offset)
+        if json_output:
+            payload = [
+                {
+                    "id": str(item.id),
+                    "document_id": str(item.document_id),
+                    "status": item.status.value,
+                    "stage": item.stage.value,
+                    "total_chunks": item.total_chunks,
+                    "completed_chunks": item.completed_chunks,
+                    "failed_chunks": item.failed_chunks,
+                    "created_at": item.created_at.isoformat(),
+                    "updated_at": item.updated_at.isoformat(),
+                    "error": item.error,
+                }
+                for item in runs
+            ]
+            console.out(json.dumps({"runs": payload}, indent=2))
+            return
         table = Table("ID", "Document", "Status", "Stage", "Chunks", "Error")
         for item in runs:
             table.add_row(
@@ -877,6 +925,10 @@ def list_runs(
 @admin_app.command("run-cancel")
 def cancel_run(
     run_id: Annotated[str, typer.Argument(help="Run ID to cancel.")],
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print a machine-readable result."),
+    ] = False,
 ) -> None:
     """Mark a queued or running run as canceled."""
 
@@ -895,6 +947,9 @@ def cancel_run(
         )
         if container.settings.job_backend == "sqlite":
             await SQLiteRunQueue(container.database).cancel(existing.id, error="canceled by user")
+        if json_output:
+            console.out(json.dumps({"run_id": str(existing.id), "status": "canceled"}))
+            return
         console.print(f"Canceled {existing.id}")
 
     asyncio.run(run())
@@ -904,6 +959,10 @@ def cancel_run(
 def retry_run(
     run_id: Annotated[str, typer.Argument(help="Failed run ID to retry.")],
     queue: Annotated[bool, typer.Option(help="Enqueue retry instead of processing now.")] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print the new run as machine-readable JSON."),
+    ] = False,
 ) -> None:
     """Replay a failed run as a new processing run."""
 
@@ -929,9 +988,17 @@ def retry_run(
                 raise typer.BadParameter(
                     f"Failed to enqueue retry {new_run.id}: {error}"
                 ) from exc
+            if json_output:
+                console.out(json.dumps({"run_id": str(new_run.id), "status": "queued"}))
+                return
             console.print(f"Queued retry {new_run.id}")
             return
         finished = await container.process_document.execute_existing(new_run.id)
+        if json_output:
+            console.out(
+                json.dumps({"run_id": str(finished.id), "status": finished.status.value})
+            )
+            return
         console.print(f"Retry {finished.id}: {finished.status.value}")
 
     asyncio.run(run())
@@ -941,12 +1008,31 @@ def retry_run(
 def inspect_queue(
     limit: Annotated[int, typer.Option(help="Maximum queue rows.", min=1, max=500)] = 100,
     offset: Annotated[int, typer.Option(help="Queue rows to skip.", min=0)] = 0,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print machine-readable queue records."),
+    ] = False,
 ) -> None:
     """List durable queue items."""
 
     async def run() -> None:
         container = await build_ingest_container()
         rows = await SQLiteRunQueue(container.database).list(limit=limit, offset=offset)
+        if json_output:
+            payload = [
+                {
+                    "run_id": str(item.run_id),
+                    "status": item.status.value,
+                    "attempts": item.attempts,
+                    "available_at": item.available_at.isoformat(),
+                    "locked_at": item.locked_at.isoformat() if item.locked_at else None,
+                    "locked_by": item.locked_by,
+                    "last_error": item.last_error,
+                }
+                for item in rows
+            ]
+            console.out(json.dumps({"queue": payload}, indent=2))
+            return
         table = Table("Run", "Status", "Attempts", "Available", "Locked By", "Error")
         for item in rows:
             table.add_row(

--- a/src/librarian/cli/app.py
+++ b/src/librarian/cli/app.py
@@ -32,7 +32,11 @@ from librarian.application.export_document import (
     transcript_citation_for_document,
 )
 from librarian.application.export_okf import OKF_VERSION, build_bundle, collect_sources
-from librarian.application.factory import build_container, build_ingest_container
+from librarian.application.factory import (
+    build_container,
+    build_ingest_container,
+    cache_wrap_extractor,
+)
 from librarian.application.import_library import (
     ImportLibrary,
     ImportProcessingMode,
@@ -755,7 +759,13 @@ def import_directory(
             else await build_container()
         )
         importer = ImportLibrary(
-            converter=DocumentConverter(_build_extractor(container.settings)),
+            converter=DocumentConverter(
+                cache_wrap_extractor(
+                    _build_extractor(container.settings),
+                    settings=container.settings,
+                    cache_store=container.repository,
+                )
+            ),
             ingest=container.ingest_document,
             process=getattr(container, "process_document", None),
             queue_factory=lambda: SQLiteRunQueue(container.database),

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -17,7 +17,7 @@ LiteParseImageMode = Literal["off", "placeholder", "embed"]
 LogFormatSetting = Literal["json", "text"]
 LogLevelSetting = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 LlmProviderSetting = Literal["mock", "openai-compatible"]
-CleaningPromptVersionSetting = Literal["cmos_v1", "cmos_v2"]
+CleaningPromptVersionSetting = Literal["cmos_v1", "cmos_v2", "cmos_v3"]
 ClassificationPromptVersionSetting = Literal[
     "dewey_v1", "dewey_v2", "dewey_v3", "dewey_v4", "dewey_v5"
 ]
@@ -57,7 +57,7 @@ class Settings(BaseSettings):
     # title + tags + series fields). 500 was too small for dewey_v5's schema.
     classification_max_output_tokens: int = Field(default=2_048, gt=0)
 
-    cleaning_prompt_version: CleaningPromptVersionSetting = Field(default="cmos_v2")
+    cleaning_prompt_version: CleaningPromptVersionSetting = Field(default="cmos_v3")
     classification_prompt_version: ClassificationPromptVersionSetting = Field(default="dewey_v5")
     cleaning_mode: CleaningModeSetting = Field(default="standard")
     coherence_mode: CoherenceModeSetting = Field(default="balanced")

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -9,6 +9,17 @@ from typing import Literal, Self
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# Settings fields that hold secrets and must never be printed or returned.
+_SECRET_SETTING_FIELDS = frozenset(
+    {
+        "api_key",
+        "api_keys",
+        "api_key_sha256",
+        "api_key_hashes",
+        "otel_headers",
+    }
+)
+
 CoherenceModeSetting = Literal["fast", "balanced", "max-coherence"]
 OcrLlmCorrectionMode = Literal["always", "never", "low-confidence"]
 OcrPreprocessMode = Literal["none", "grayscale", "threshold", "deskew"]
@@ -190,4 +201,21 @@ class Settings(BaseSettings):
                 "llm_retry_max_delay_seconds must be greater than or equal to "
                 "llm_retry_base_delay_seconds"
             )
+        if self.figure_vision_min_bytes > self.figure_vision_max_bytes:
+            raise ValueError(
+                "figure_vision_min_bytes must be less than or equal to figure_vision_max_bytes"
+            )
         return self
+
+    def redacted_config(self) -> dict[str, object]:
+        """Return the effective configuration with secret values redacted.
+
+        Field values that hold credentials (raw and hashed API keys, OTLP
+        headers) are replaced with a marker so the result is safe to log,
+        print, or return from an endpoint.
+        """
+        payload = self.model_dump(mode="json")
+        for name in _SECRET_SETTING_FIELDS:
+            if payload.get(name) is not None:
+                payload[name] = "***redacted***"
+        return payload

--- a/src/librarian/config.py
+++ b/src/librarian/config.py
@@ -49,6 +49,13 @@ class Settings(BaseSettings):
     llm_completion_cost_per_1k_tokens_usd: float = Field(default=0.0, ge=0)
     llm_max_prompt_chars: int = Field(default=2 * 1024 * 1024, gt=0)
     llm_max_response_chars: int = Field(default=2 * 1024 * 1024, gt=0)
+    # Output token budget for chunk cleaning. Must exceed the tokens needed to
+    # return a fully-cleaned chunk (~chunk_target_chars); token-dense text
+    # (CJK, tables, dense OCR) needs headroom or the provider truncates.
+    llm_max_output_tokens: int = Field(default=16_384, gt=0)
+    # Output token budget for classification JSON (summary + description +
+    # title + tags + series fields). 500 was too small for dewey_v5's schema.
+    classification_max_output_tokens: int = Field(default=2_048, gt=0)
 
     cleaning_prompt_version: CleaningPromptVersionSetting = Field(default="cmos_v2")
     classification_prompt_version: ClassificationPromptVersionSetting = Field(default="dewey_v5")

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -9,6 +9,7 @@ import importlib
 import importlib.util
 import json
 import logging
+import math
 import multiprocessing
 import queue
 import re
@@ -17,7 +18,7 @@ import subprocess
 import tempfile
 import time
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
@@ -198,10 +199,10 @@ class DocxExtractor:
         from docx import Document
 
         doc = Document(str(path))
-        parts = [
-            *(_paragraph_text(paragraph) for paragraph in doc.paragraphs),
-            *(_table_text(table) for table in doc.tables),
-        ]
+        # Iterate the body in true document order so a table that sits between
+        # two paragraphs stays between them, instead of hoisting every table to
+        # the end (which scrambled the reading order of mixed documents).
+        parts = list(_iter_docx_body_text(doc))
         for section in doc.sections:
             parts.extend(_paragraph_text(paragraph) for paragraph in section.header.paragraphs)
             parts.extend(_table_text(table) for table in section.header.tables)
@@ -513,6 +514,7 @@ class PdfExtractor:
             "ocr_threshold": self.ocr_threshold,
             "ocr_preserve_page_images": self.ocr_preserve_page_images,
             "ocr_rotation_retry": self.ocr_rotation_retry,
+            "ocr_auto_orient": self.ocr_auto_orient,
             "ocr_correction_mode": self.ocr_correction_mode,
             "ocr_correction_model": self.ocr_correction_model,
             "ocr_low_confidence_threshold": self.ocr_low_confidence_threshold,
@@ -883,6 +885,11 @@ async def enrich_markdown_figures(
     if not eligible:
         return markdown, 0
 
+    # Derive the token ceiling from the character budget rather than hardcoding
+    # it: a description is truncated to max_response_chars anyway, so asking for
+    # far more tokens just wastes latency and cost, while a tiny fixed cap would
+    # clip a large configured budget. ~4 chars/token with headroom and a floor.
+    vision_max_tokens = max(256, math.ceil(max_response_chars / 3))
     semaphore = asyncio.Semaphore(max(1, max_concurrency))
 
     async def describe(figure: FigureImage) -> tuple[FigureImage, str | None]:
@@ -894,7 +901,7 @@ async def enrich_markdown_figures(
                     system_prompt=FIGURE_VISION_SYSTEM_PROMPT,
                     user_prompt=FIGURE_VISION_USER_PROMPT,
                     model=model,
-                    max_tokens=2048,
+                    max_tokens=vision_max_tokens,
                     temperature=temperature,
                 )
             except Exception:  # noqa: BLE001 - one figure must not fail the document
@@ -1025,6 +1032,7 @@ class LiteParseExtractor:
                     output_dir=Path(tmp_dir),
                     auto_orient=self.auto_orient,
                     ocr_timeout_seconds=self.ocr_timeout_seconds,
+                    fallback_dpi=self.dpi,
                 )
                 return self._collect_result(parser.parse(str(pdf_path)))
         return self._collect_result(parser.parse(str(path)))
@@ -1343,6 +1351,11 @@ class CompositeExtractor:
                 "liteparse_ocr_server_url": liteparse_ocr_server_url,
                 "liteparse_dpi": liteparse_dpi,
                 "liteparse_image_mode": liteparse_image_mode,
+                # The bundled tessdata models change OCR output, so a different
+                # path must invalidate cached liteparse extractions.
+                "liteparse_tessdata_path": (
+                    liteparse_tessdata_path if self.liteparse_active else None
+                ),
                 # Every vision knob that changes which figures are described, or
                 # how much text each yields, must invalidate the cache when the
                 # vision pass is active (gated so toggling unrelated knobs while
@@ -1604,6 +1617,7 @@ def _image_to_single_page_pdf(
     output_dir: Path,
     auto_orient: bool,
     ocr_timeout_seconds: int,
+    fallback_dpi: int = 150,
 ) -> Path:
     """Render a loose image as a one-page PDF so liteparse can parse it.
 
@@ -1613,6 +1627,10 @@ def _image_to_single_page_pdf(
     full liteparse pipeline -- tables, headings, figures -- without that
     heavyweight dependency. The image is oriented upright first so rotated
     photos and scans extract correctly.
+
+    The PDF resolution is taken from the image's embedded DPI when present so
+    the page keeps its true physical size; otherwise ``fallback_dpi`` is used.
+    A hardcoded resolution would stretch or shrink pages whose real DPI differs.
     """
     try:
         image_module = importlib.import_module("PIL.Image")
@@ -1640,17 +1658,47 @@ def _image_to_single_page_pdf(
 
     pdf_path = output_dir / f"{image_path.stem}.liteparse.pdf"
     with image_module.open(source) as image:
+        resolution = _image_resolution(image, fallback_dpi=fallback_dpi)
         pages = [_flatten_to_white(frame, image_module) for frame in image_sequence.Iterator(image)]
     if not pages:  # pragma: no cover - Pillow always yields at least one frame
         raise ValueError(f"No image frames found: {image_path}")
     pages[0].save(
         pdf_path,
         "PDF",
-        resolution=200.0,
+        resolution=resolution,
         save_all=len(pages) > 1,
         append_images=pages[1:],
     )
     return pdf_path
+
+
+def _image_resolution(image: Any, *, fallback_dpi: int) -> float:
+    """Return the image's embedded horizontal DPI, or the fallback if absent."""
+    info = getattr(image, "info", None)
+    if not isinstance(info, dict):
+        return float(fallback_dpi)
+    dpi_value = cast("Any", info).get("dpi")
+    try:
+        horizontal = float(dpi_value[0])
+    except (TypeError, ValueError, IndexError):
+        return float(fallback_dpi)
+    return horizontal if horizontal > 0 else float(fallback_dpi)
+
+
+def _apply_exif_orientation(image: Any) -> Any:
+    """Bake in an image's EXIF orientation tag (best effort).
+
+    Phone cameras and scanners often store pixels in the sensor's native
+    orientation plus an EXIF tag telling viewers how to rotate them. Pillow
+    does not apply that tag on open, so a "portrait" photo would otherwise be
+    OCR'd sideways. ``exif_transpose`` rewrites the pixels to match the tag and
+    is a no-op when no orientation tag is present.
+    """
+    try:
+        image_ops = importlib.import_module("PIL.ImageOps")
+        return image_ops.exif_transpose(image)
+    except Exception:  # noqa: BLE001 - orientation is best-effort
+        return image
 
 
 def _flatten_to_white(image: Any, image_module: Any) -> Any:
@@ -1658,8 +1706,10 @@ def _flatten_to_white(image: Any, image_module: Any) -> Any:
 
     ``Image.convert("RGB")`` merely drops the alpha channel, so transparent
     pixels become black (unreadable OCR that still looks like a valid page).
-    Alpha-compositing onto white preserves the intended appearance.
+    Alpha-compositing onto white preserves the intended appearance. The frame's
+    EXIF orientation is applied first so rotated photos land upright.
     """
+    image = _apply_exif_orientation(image)
     if image.mode in ("RGBA", "LA", "PA") or (image.mode == "P" and "transparency" in image.info):
         rgba = image.convert("RGBA")
         background = image_module.new("RGBA", rgba.size, (255, 255, 255, 255))
@@ -1682,7 +1732,7 @@ def _prepare_ocr_image(
     except ImportError as exc:
         raise RuntimeError("OCR preprocessing requires installing the 'ocr' extra") from exc
 
-    image = image_module.open(path)
+    image = _apply_exif_orientation(image_module.open(path))
     grayscale = image.convert("L")
     if preprocess_mode == "grayscale":
         prepared = grayscale
@@ -2400,6 +2450,26 @@ def _reject_disallowed_archive_signature(path: Path, payload: bytes) -> None:
     if label == "zip" and path.suffix.lower() in ZIP_CONTAINER_EXTENSIONS:
         return
     raise ValueError(f"Archive inputs are not supported by default: {label} signature detected")
+
+
+def _iter_docx_body_text(doc: Any) -> Iterator[str]:
+    """Yield DOCX body paragraphs and tables in document order.
+
+    ``doc.paragraphs`` and ``doc.tables`` are separate flat lists, so emitting
+    one after the other loses the interleaving of the original document. Walking
+    the body's child elements preserves the real reading order.
+    """
+    from docx.oxml.ns import qn
+    from docx.table import Table
+    from docx.text.paragraph import Paragraph
+
+    paragraph_tag = qn("w:p")
+    table_tag = qn("w:tbl")
+    for child in doc.element.body.iterchildren():
+        if child.tag == paragraph_tag:
+            yield _paragraph_text(Paragraph(child, doc))
+        elif child.tag == table_tag:
+            yield _table_text(Table(child, doc))
 
 
 def _paragraph_text(paragraph: Any) -> str:

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -8,6 +8,7 @@ import hashlib
 import importlib
 import importlib.util
 import json
+import logging
 import multiprocessing
 import queue
 import re
@@ -17,6 +18,7 @@ import tempfile
 import time
 import uuid
 from collections.abc import Mapping, Sequence
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast
@@ -28,6 +30,8 @@ from librarian.application.transcripts import (
 )
 from librarian.observability import sanitize_error_message
 from librarian.pipeline.validation import validate_cleaned_text
+
+_LOGGER = logging.getLogger("librarian.ingest.extractors")
 
 IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp"})
 ARCHIVE_EXTENSIONS = frozenset({".zip", ".tar", ".tgz", ".gz", ".bz2", ".xz", ".7z", ".rar"})
@@ -206,6 +210,23 @@ class DocxExtractor:
         return "\n\n".join(part for part in parts if part.strip())
 
 
+# Durable page-manifest path for the extraction running in the current asyncio
+# task. Held in a ContextVar (not on the shared extractor instance) so that
+# concurrent conversions never overwrite each other's manifest target.
+_page_manifest_path_var: ContextVar[Path | None] = ContextVar(
+    "librarian_page_manifest_path", default=None
+)
+
+
+def reset_page_manifest_path() -> None:
+    """Clear the current context's page-manifest path.
+
+    Public entry point for callers (and tests) that need to reset the
+    ContextVar without reaching into module-private state.
+    """
+    _page_manifest_path_var.set(None)
+
+
 class PdfExtractor:
     """Extractor for text-bearing PDFs."""
 
@@ -255,11 +276,20 @@ class PdfExtractor:
         self.max_pages = max_pages
         self.metrics = metrics
         self.last_metadata: dict[str, object] | None = None
-        self.page_manifest_path: Path | None = None
+
+    @property
+    def page_manifest_path(self) -> Path | None:
+        return _page_manifest_path_var.get()
 
     def set_page_manifest_path(self, path: Path | None) -> None:
-        """Set an optional durable manifest path for page-level extraction state."""
-        self.page_manifest_path = path
+        """Set the durable page-manifest path for the current extraction.
+
+        Stored in a ContextVar rather than on the instance: extractors are
+        shared across concurrent conversions (import_concurrency > 1), so
+        per-instance state would let one document's pages/provenance be written
+        into another's sidecar. A ContextVar is isolated per asyncio task.
+        """
+        _page_manifest_path_var.set(path)
 
     async def extract(self, path: Path) -> str:
         _validate_input_size(path, self.max_input_bytes, "PDF extraction input")
@@ -1039,16 +1069,22 @@ class FallbackExtractor:
             text = await self._primary.extract(path)
             self.last_metadata = _extractor_metadata(self._primary)
             return text
-        except Exception:  # noqa: BLE001 - intentional fallback to the legacy extractor
+        except Exception as exc:  # noqa: BLE001 - intentional fallback to the legacy extractor
+            # A silent engine downgrade (e.g. a permanently broken liteparse
+            # install) is otherwise undiagnosable, so record why we fell back.
+            primary_error = sanitize_error_message(exc)
+            _LOGGER.warning(
+                "primary extractor failed for %s; falling back: %s", path.name, primary_error
+            )
             text = await self._fallback.extract(path)
-            self.last_metadata = _extractor_metadata(self._fallback)
+            metadata = dict(_extractor_metadata(self._fallback) or {})
+            metadata["fallback_from_primary"] = True
+            metadata["primary_error"] = primary_error
+            self.last_metadata = metadata
             return text
 
     def set_page_manifest_path(self, path: Path | None) -> None:
-        for extractor in (self._primary, self._fallback):
-            setter = getattr(extractor, "set_page_manifest_path", None)
-            if callable(setter):
-                setter(path)
+        _page_manifest_path_var.set(path)
 
 
 class TextExtractorLike(Protocol):
@@ -1131,16 +1167,20 @@ class CachingExtractor:
         self.supported_extensions = inner.supported_extensions
         self.last_metadata: dict[str, object] | None = None
         self.last_cache_hit: bool | None = None
-        self._manifest_path: Path | None = None
 
     async def extract(self, path: Path) -> str:
-        # A page-manifest request (the convert sidecar flow) needs the real
-        # per-page extraction to run, so bypass the cache while one is active.
-        if self._manifest_path is not None:
-            return await self._extract_uncached(path)
-
+        # Cache composes with the page-manifest/sidecar flow: on a hit we return
+        # the cached Markdown (no OCR runs, so no per-page manifest is needed);
+        # on a miss the real extraction runs with the manifest active and the
+        # result is cached. This lets re-imports of unchanged files skip
+        # extraction, which the previous unconditional bypass prevented.
+        extension = path.suffix.lower()
+        # Fold the extension into the key: identical bytes can render very
+        # differently by extension (.json vs .txt, .srt vs .txt), so they must
+        # not share a cache slot.
+        signature = f"{self._config_signature}:{extension}"
         content_sha256 = await asyncio.to_thread(_file_sha256, path)
-        cached = await self._cache.get_extraction(content_sha256, self._config_signature)
+        cached = await self._cache.get_extraction(content_sha256, signature)
         if cached is not None:
             self.last_cache_hit = True
             self.last_metadata = {
@@ -1154,8 +1194,8 @@ class CachingExtractor:
         await self._cache.put_extraction(
             ExtractionCacheEntry(
                 content_sha256=content_sha256,
-                config_signature=self._config_signature,
-                source_extension=path.suffix.lower(),
+                config_signature=signature,
+                source_extension=extension,
                 text=text,
             )
         )
@@ -1168,10 +1208,7 @@ class CachingExtractor:
         return text
 
     def set_page_manifest_path(self, path: Path | None) -> None:
-        self._manifest_path = path
-        setter = getattr(self._inner, "set_page_manifest_path", None)
-        if callable(setter):
-            setter(path)
+        _page_manifest_path_var.set(path)
 
 
 class CompositeExtractor:
@@ -1370,11 +1407,8 @@ class CompositeExtractor:
             ) from exc
 
     def set_page_manifest_path(self, path: Path | None) -> None:
-        """Forward page manifest paths to extractors that support them."""
-        for extractor in self._extractors.values():
-            setter = getattr(extractor, "set_page_manifest_path", None)
-            if callable(setter):
-                setter(path)
+        """Set the page-manifest path for the current task's extraction."""
+        _page_manifest_path_var.set(path)
 
 
 def _ocr_image(

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -1490,43 +1490,25 @@ def _ocr_image_result(
             preprocess_mode=preprocess_mode,
             threshold=threshold,
         )
-        completed = _run_tesseract(
+        # Single tesseract pass produces both the plain text and the TSV used
+        # for the confidence estimate; running it twice doubled the per-page OCR
+        # cost for no benefit.
+        outputs = _run_tesseract_to_files(
             prepared_path,
             tesseract_path=tesseract_path,
             language=language,
             timeout_seconds=timeout_seconds,
+            output_dir=Path(tmp_dir),
+            formats=("txt", "tsv"),
         )
-        text = completed.stdout.strip()
+        text = outputs["txt"].strip()
         if not text:
             raise ValueError(f"No OCR text found in image: {path}")
         try:
-            confidence = _ocr_image_confidence(
-                prepared_path,
-                language=language,
-                timeout_seconds=timeout_seconds,
-            )
+            confidence = parse_tesseract_tsv_confidence(outputs["tsv"])
         except Exception:  # noqa: BLE001 - confidence is optional diagnostics
             confidence = None
     return OcrTextResult(text=text, confidence=confidence)
-
-
-def _ocr_image_confidence(
-    path: Path,
-    *,
-    language: str = "eng",
-    timeout_seconds: int = 120,
-) -> float | None:
-    tesseract_path = shutil.which("tesseract")
-    if tesseract_path is None:
-        raise RuntimeError("OCR requires the 'tesseract' executable on PATH")
-    completed = _run_tesseract(
-        path,
-        tesseract_path=tesseract_path,
-        language=language,
-        timeout_seconds=timeout_seconds,
-        output_format="tsv",
-    )
-    return parse_tesseract_tsv_confidence(completed.stdout)
 
 
 def _run_tesseract(
@@ -1547,6 +1529,35 @@ def _run_tesseract(
         text=True,
         timeout=timeout_seconds,
     )
+
+
+def _run_tesseract_to_files(
+    path: Path,
+    *,
+    tesseract_path: str,
+    language: str,
+    timeout_seconds: int,
+    output_dir: Path,
+    formats: tuple[str, ...],
+) -> dict[str, str]:
+    """Run tesseract once, emitting several output formats, and read them back.
+
+    Passing multiple format configs (e.g. ``txt tsv``) to a single tesseract
+    invocation produces all of them from one recognition pass, instead of
+    spawning the process once per format.
+    """
+    output_base = output_dir / "tesseract_output"
+    command = [tesseract_path, str(path), str(output_base), "-l", language, *formats]
+    subprocess.run(  # noqa: S603
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+    return {
+        fmt: output_base.with_suffix(f".{fmt}").read_text(encoding="utf-8") for fmt in formats
+    }
 
 
 _OSD_ROTATE_RE = re.compile(r"^Rotate:\s*(\d+)", re.MULTILINE)

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -718,15 +718,23 @@ class MarkItDownExtractor:
             daemon=True,
         )
         process.start()
-        process.join(self.timeout_seconds)
+        # Read the result BEFORE joining. A multiprocessing.Queue payload larger
+        # than the OS pipe buffer (~64 KiB) blocks the child's feeder thread
+        # until the parent drains it, so join()-before-get() deadlocks on any
+        # sizeable conversion and surfaces a false TimeoutError. Draining first
+        # lets the child flush and exit.
+        try:
+            status, payload = result_queue.get(timeout=self.timeout_seconds)
+        except queue.Empty:
+            process.terminate()
+            process.join(5)
+            raise TimeoutError(
+                f"Broad format conversion timed out after {self.timeout_seconds}s"
+            ) from None
+        process.join(5)
         if process.is_alive():
             process.terminate()
             process.join()
-            raise TimeoutError(f"Broad format conversion timed out after {self.timeout_seconds}s")
-        try:
-            status, payload = result_queue.get_nowait()
-        except queue.Empty as exc:
-            raise RuntimeError("Broad format conversion failed without returning a result") from exc
         if status == "ok":
             return payload
         raise RuntimeError(payload)
@@ -1574,12 +1582,19 @@ def _image_to_single_page_pdf(
     """
     try:
         image_module = importlib.import_module("PIL.Image")
+        image_sequence = importlib.import_module("PIL.ImageSequence")
     except ImportError as exc:
         raise RuntimeError(
             "liteparse image extraction requires Pillow (install the 'ocr' extra)"
         ) from exc
+
+    with image_module.open(image_path) as probe:
+        multi_frame = getattr(probe, "n_frames", 1) > 1
+
+    # Auto-orient only single-frame images: it re-saves one frame and would drop
+    # the rest of a multi-page TIFF. Multi-frame scans are handled page-by-page.
     source = image_path
-    if auto_orient:
+    if auto_orient and not multi_frame:
         tesseract_path = shutil.which("tesseract")
         if tesseract_path is not None:
             source = auto_orient_image(
@@ -1588,12 +1603,34 @@ def _image_to_single_page_pdf(
                 timeout_seconds=ocr_timeout_seconds,
                 output_dir=output_dir,
             )
+
     pdf_path = output_dir / f"{image_path.stem}.liteparse.pdf"
     with image_module.open(source) as image:
-        # Flatten onto white so transparency does not become a black page.
-        rgb = image.convert("RGB")
-        rgb.save(pdf_path, "PDF", resolution=200.0)
+        pages = [_flatten_to_white(frame, image_module) for frame in image_sequence.Iterator(image)]
+    if not pages:  # pragma: no cover - Pillow always yields at least one frame
+        raise ValueError(f"No image frames found: {image_path}")
+    pages[0].save(
+        pdf_path,
+        "PDF",
+        resolution=200.0,
+        save_all=len(pages) > 1,
+        append_images=pages[1:],
+    )
     return pdf_path
+
+
+def _flatten_to_white(image: Any, image_module: Any) -> Any:
+    """Composite a possibly-transparent frame onto a white RGB background.
+
+    ``Image.convert("RGB")`` merely drops the alpha channel, so transparent
+    pixels become black (unreadable OCR that still looks like a valid page).
+    Alpha-compositing onto white preserves the intended appearance.
+    """
+    if image.mode in ("RGBA", "LA", "PA") or (image.mode == "P" and "transparency" in image.info):
+        rgba = image.convert("RGBA")
+        background = image_module.new("RGBA", rgba.size, (255, 255, 255, 255))
+        return image_module.alpha_composite(background, rgba).convert("RGB")
+    return image.convert("RGB")
 
 
 def _prepare_ocr_image(

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -1808,6 +1808,16 @@ def _ocr_deskew_score(image: Any, angle: float, *, threshold: int) -> float:
     if width == 0 or height == 0:
         return 0.0
     data = rotated.tobytes()
+    numpy_module = _optional_numpy()
+    if numpy_module is not None:
+        # Vectorized: variance of the per-row ink counts. The pure-Python path
+        # below is O(width*height) in interpreter loops and dominates deskew
+        # cost across the 21 candidate angles.
+        pixels = numpy_module.frombuffer(data, dtype=numpy_module.uint8).reshape(height, width)
+        row_counts = (pixels <= threshold).sum(axis=1)
+        if not row_counts.any():
+            return 0.0
+        return float(row_counts.var())
     row_counts = [
         sum(1 for pixel in data[row * width : (row + 1) * width] if pixel <= threshold)
         for row in range(height)
@@ -1816,6 +1826,13 @@ def _ocr_deskew_score(image: Any, angle: float, *, threshold: int) -> float:
         return 0.0
     mean = sum(row_counts) / len(row_counts)
     return sum((count - mean) ** 2 for count in row_counts) / len(row_counts)
+
+
+def _optional_numpy() -> Any | None:
+    try:
+        return importlib.import_module("numpy")
+    except ImportError:
+        return None
 
 
 def parse_tesseract_tsv_confidence(tsv: str) -> float | None:

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -841,6 +841,10 @@ _FIGURE_MEDIA_TYPES = {
     "webp": "image/webp",
 }
 
+# Upper bound on the tokens requested per figure description, so a very large
+# configured character budget can't derive an output-token count providers reject.
+_MAX_FIGURE_VISION_TOKENS = 8_192
+
 
 def figure_media_type(image_format: str) -> str:
     """Map a liteparse image format to an IANA media type (default PNG)."""
@@ -888,8 +892,10 @@ async def enrich_markdown_figures(
     # Derive the token ceiling from the character budget rather than hardcoding
     # it: a description is truncated to max_response_chars anyway, so asking for
     # far more tokens just wastes latency and cost, while a tiny fixed cap would
-    # clip a large configured budget. ~4 chars/token with headroom and a floor.
-    vision_max_tokens = max(256, math.ceil(max_response_chars / 3))
+    # clip a large configured budget. ~4 chars/token with headroom and a floor,
+    # and an upper bound so an unusually large char budget can't request an
+    # absurd token count that providers reject.
+    vision_max_tokens = min(_MAX_FIGURE_VISION_TOKENS, max(256, math.ceil(max_response_chars / 3)))
     semaphore = asyncio.Semaphore(max(1, max_concurrency))
 
     async def describe(figure: FigureImage) -> tuple[FigureImage, str | None]:

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -1408,6 +1408,15 @@ class CompositeExtractor:
         return text
 
     async def _extract_with_timeout(self, extractor: TextExtractorLike, path: Path) -> str:
+        """Bound how long the caller waits for an extraction.
+
+        This unblocks the pipeline after the deadline and discards the result.
+        Extractors that shell out (OCR via ``subprocess.run(timeout=...)``, the
+        MarkItDown subprocess) are hard-cancelled at their own layer. A purely
+        CPU-bound in-thread extractor cannot be force-killed by Python, so its
+        thread may keep running to completion in the background even though we
+        stop waiting -- we log that case so a runaway extraction is visible.
+        """
         if self._extraction_timeout_seconds <= 0:
             return await extractor.extract(path)
         try:
@@ -1415,6 +1424,13 @@ class CompositeExtractor:
                 extractor.extract(path), timeout=self._extraction_timeout_seconds
             )
         except TimeoutError as exc:
+            _LOGGER.warning(
+                "extraction_timeout",
+                extra={
+                    "path": path.name,
+                    "timeout_seconds": self._extraction_timeout_seconds,
+                },
+            )
             raise ExtractionTimeoutError(
                 f"Extraction exceeded {self._extraction_timeout_seconds}s: {path.name}"
             ) from exc

--- a/src/librarian/llm/openai_compatible.py
+++ b/src/librarian/llm/openai_compatible.py
@@ -20,6 +20,26 @@ from openai.types.chat import ChatCompletion
 from librarian.observability import sanitize_error_message
 
 
+class LLMResponseTruncatedError(RuntimeError):
+    """Raised when the model stopped because it hit the output token cap.
+
+    Silently returning a truncated completion is a correctness hazard — the
+    caller (chunk cleaner, classifier) cannot tell a mid-sentence cutoff from a
+    complete answer — so we fail loudly and let it surface as a run error.
+    """
+
+
+def _content_or_raise(response: ChatCompletion) -> str:
+    """Return the completion text, raising if the model output was truncated."""
+    choice = response.choices[0]
+    if getattr(choice, "finish_reason", None) == "length":
+        raise LLMResponseTruncatedError(
+            "LLM response was truncated at the output token limit; "
+            "increase max_tokens (LIBRARIAN_LLM_MAX_OUTPUT_TOKENS)"
+        )
+    return choice.message.content or ""
+
+
 class LLMUsageMetrics(Protocol):
     """Metrics sink for provider token usage."""
 
@@ -88,7 +108,7 @@ class OpenAICompatibleProvider:
                 temperature=temperature,
             )
         self._record_usage(response, model=model)
-        return response.choices[0].message.content or ""
+        return _content_or_raise(response)
 
     async def describe_image(
         self,
@@ -122,7 +142,7 @@ class OpenAICompatibleProvider:
                 temperature=temperature,
             )
         self._record_usage(response, model=model)
-        return response.choices[0].message.content or ""
+        return _content_or_raise(response)
 
     async def _chat_with_retries(
         self,

--- a/src/librarian/observability.py
+++ b/src/librarian/observability.py
@@ -23,9 +23,11 @@ _SECRET_REPLACEMENTS = (
         re.compile(r"(?i)\b(api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)"),
         r"\1\2[REDACTED]",
     ),
-    # Credentials embedded in a URL: scheme://user:password@host -> mask the password.
+    # Credentials embedded in a URL: scheme://[user]:password@host -> mask the
+    # password. The username is optional so DSNs like redis://:secret@host also
+    # redact.
     (
-        re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://[^/\s:@]+):([^/\s@]+)@"),
+        re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://[^/\s:@]*):([^/\s@]+)@"),
         r"\1:[REDACTED]@",
     ),
     # Bearer tokens, whether or not preceded by an Authorization header name.

--- a/src/librarian/observability.py
+++ b/src/librarian/observability.py
@@ -23,8 +23,22 @@ _SECRET_REPLACEMENTS = (
         re.compile(r"(?i)\b(api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)"),
         r"\1\2[REDACTED]",
     ),
-    (re.compile(r"(?i)\b(authorization:\s*bearer\s+)([^\s,;]+)"), r"\1[REDACTED]"),
+    # Credentials embedded in a URL: scheme://user:password@host -> mask the password.
+    (
+        re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://[^/\s:@]+):([^/\s@]+)@"),
+        r"\1:[REDACTED]@",
+    ),
+    # Bearer tokens, whether or not preceded by an Authorization header name.
+    (re.compile(r"(?i)\b(bearer\s+)([A-Za-z0-9._~+/=-]{8,})"), r"\1[REDACTED]"),
     (re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"), "[REDACTED]"),
+    # GitHub personal/OAuth/app/refresh tokens (ghp_, gho_, ghu_, ghs_, ghr_).
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"), "[REDACTED]"),
+    # Slack bot/user/app/refresh tokens.
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), "[REDACTED]"),
+    # AWS access key IDs.
+    (re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"), "[REDACTED]"),
+    # Google API keys.
+    (re.compile(r"\bAIza[0-9A-Za-z._-]{35,}\b"), "[REDACTED]"),
 )
 _MAX_STORED_ERROR_CHARS = 1_000
 

--- a/src/librarian/pipeline/chunking.py
+++ b/src/librarian/pipeline/chunking.py
@@ -14,7 +14,14 @@ _BOUNDARY_PATTERN = re.compile(r"\n(?=#{1,6}\s)|\n{2,}|(?<=[.!?])\s+")
 
 @dataclass(frozen=True, slots=True)
 class ChunkingPolicy:
-    """Chunking controls."""
+    """Chunking controls.
+
+    ``overlap_chars`` is **not** re-emitted into adjacent chunks (doing so
+    duplicated ~``overlap_chars`` of content at every chunk seam in the final
+    document). Chunks tile the source exactly at clean sentence/paragraph
+    boundaries; cross-boundary continuity for the cleaner is provided separately
+    as read-only *context* (see ``CleanChunks``), sized by ``overlap_chars``.
+    """
 
     target_chars: int = 12_000
     overlap_chars: int = 800
@@ -60,10 +67,10 @@ def chunk_text(document_id: DocumentId, text: str, policy: ChunkingPolicy) -> li
         if end >= text_length:
             break
 
-        next_start = max(end - policy.overlap_chars, 0)
-        if next_start <= start:
-            next_start = end
-        start = _skip_leading_space(normalized, next_start)
+        # Tile exactly: the next chunk starts where this one ended (a boundary
+        # chosen by _choose_boundary), so no source region is emitted twice.
+        # Continuity is handled by read-only cleaning context, not re-emission.
+        start = _skip_leading_space(normalized, end)
 
     return chunks
 

--- a/src/librarian/prompts/cleaning/cmos_v3.md
+++ b/src/librarian/prompts/cleaning/cmos_v3.md
@@ -1,0 +1,32 @@
+You are an expert senior copy editor and archivist with decades of experience.
+Your task is to transform raw transcripts, OCR output, notes, and mixed document text into polished,
+professional prose while preserving source fidelity.
+
+Follow the Chicago Manual of Style unless the source clearly requires a domain-specific convention.
+
+Core responsibilities:
+1. Contextual correction: fix likely mis-transcriptions and OCR errors using local context, including
+   homophones, broken line endings, split words, and domain-specific terminology.
+2. Grammar and syntax: repair fragments, run-ons, agreement errors, capitalization errors, and rough
+   speech-to-text punctuation.
+3. Punctuation and typography: apply standard CMOS punctuation, serial commas, quotation marks,
+   apostrophes, and dash usage.
+4. Structure: preserve headings, lists, page markers, citations, code blocks, tables, and meaningful
+   paragraph order. Do not flatten a structured document into one paragraph. Keep Markdown tables as
+   Markdown tables with the same rows, columns, and cell values.
+5. Fidelity: do not summarize, paraphrase away detail, delete substantive content, invent facts,
+   reorder sections, or change the author's voice. Remove only pure filler, repeated stutters, obvious
+   false starts, and mechanical OCR noise.
+6. Verbatim data: reproduce numbers, currency amounts, percentages, units of measure, dates, times,
+   equations, code, identifiers (SKUs, case numbers, citations, URLs, DOIs), and proper names exactly
+   as written. Do not round, convert units, reformat dates, normalize number separators, or "correct"
+   a figure to what you think it should be. If OCR clearly mangled a digit or symbol and the correct
+   value is unambiguous from context, fix it; otherwise leave it as written rather than guessing.
+7. Continuity: when the user input begins with a context note, use it only to maintain continuity.
+   Do not include the context note in the output.
+
+Return only the cleaned text. Do not include preambles, postscript, explanations, confidence notes,
+or phrases such as "Here is the cleaned text."
+
+If the input is long or appears to be one chunk of a larger work, produce the cleaned version of this
+chunk only, corresponding 1:1 with the flow and amount of the input.

--- a/src/librarian/runtime/__init__.py
+++ b/src/librarian/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Process-lifecycle helpers for the Librarian runtime."""

--- a/src/librarian/runtime/parent_watch.py
+++ b/src/librarian/runtime/parent_watch.py
@@ -1,0 +1,89 @@
+"""Terminate the backend when a designated parent process dies.
+
+Desktop launchers (e.g. the macOS app) start the API as a child process and
+pass their own PID via ``LIBRARIAN_PARENT_PID``. If the launcher crashes or is
+force-quit, the child would otherwise linger as an orphan holding the port.
+This watcher polls the parent and shuts the backend down when it disappears.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+import time
+from collections.abc import Mapping
+
+PARENT_PID_ENV = "LIBRARIAN_PARENT_PID"
+
+_LOGGER = logging.getLogger("librarian.runtime.parent_watch")
+
+
+def parent_pid_from_env(env: Mapping[str, str] | None = None) -> int | None:
+    """Parse a valid, watchable parent PID from the environment, if configured."""
+    environ = os.environ if env is None else env
+    raw = environ.get(PARENT_PID_ENV)
+    if not raw:
+        return None
+    try:
+        parent_pid = int(raw)
+    except ValueError:
+        return None
+    # PID 1 (init/launchd) is not a meaningful parent to watch, and non-positive
+    # PIDs are invalid.
+    if parent_pid <= 1:
+        return None
+    return parent_pid
+
+
+def process_alive(pid: int) -> bool:
+    """Return whether a process with ``pid`` currently exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The process exists but is owned by another user.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def start_parent_death_watcher(
+    *,
+    poll_interval_seconds: float = 2.0,
+    env: Mapping[str, str] | None = None,
+) -> threading.Thread | None:
+    """Start a daemon thread that shuts the process down if the parent dies.
+
+    Returns the watcher thread, or ``None`` when no valid parent PID is
+    configured (so the backend runs normally when launched standalone).
+    """
+    parent_pid = parent_pid_from_env(env)
+    if parent_pid is None:
+        return None
+
+    def watch() -> None:
+        while True:
+            time.sleep(poll_interval_seconds)
+            if not process_alive(parent_pid):
+                _LOGGER.warning(
+                    "parent process %d exited; shutting down backend", parent_pid
+                )
+                _terminate_self()
+                return
+
+    thread = threading.Thread(target=watch, name="librarian-parent-watch", daemon=True)
+    thread.start()
+    return thread
+
+
+def _terminate_self() -> None:
+    # Prefer a graceful SIGTERM so the server can unwind; fall back to a hard
+    # exit if the signal is unavailable or ignored.
+    try:
+        os.kill(os.getpid(), signal.SIGTERM)
+    except (OSError, ValueError, AttributeError):
+        os._exit(1)

--- a/src/librarian/storage/migrations/0010_performance_indexes.sql
+++ b/src/librarian/storage/migrations/0010_performance_indexes.sql
@@ -1,0 +1,24 @@
+-- Indexes for the hot read paths that previously forced table scans.
+
+-- list_events / SSE streaming: filter by run_id, order by id.
+CREATE INDEX IF NOT EXISTS idx_run_events_run_id
+  ON run_events(run_id, id);
+
+-- Runs by document (history, reprocess lookups) and the runs list ordering.
+CREATE INDEX IF NOT EXISTS idx_runs_document_id
+  ON runs(document_id);
+CREATE INDEX IF NOT EXISTS idx_runs_created_at
+  ON runs(created_at DESC);
+
+-- Document listing is ordered newest-first.
+CREATE INDEX IF NOT EXISTS idx_documents_created_at
+  ON documents(created_at DESC);
+
+-- cleaned_outputs' primary key is (document_id, run_id), so lookups and
+-- cascade cleanup keyed on run_id alone had no supporting index.
+CREATE INDEX IF NOT EXISTS idx_cleaned_outputs_run_id
+  ON cleaned_outputs(run_id);
+
+-- cleaned_chunks joins runs back to chunk output on chunk_id.
+CREATE INDEX IF NOT EXISTS idx_cleaned_chunks_chunk_id
+  ON cleaned_chunks(chunk_id);

--- a/src/librarian/storage/migrations/0011_fts_porter_stemming.sql
+++ b/src/librarian/storage/migrations/0011_fts_porter_stemming.sql
@@ -1,0 +1,27 @@
+-- Rebuild the full-text indexes with Porter stemming so queries match
+-- inflected forms (search "dividends" -> matches "dividend", "running" ->
+-- "run"). The tables are repopulated from their source-of-truth rows, so no
+-- content is lost; only the tokenizer changes.
+
+DROP TABLE IF EXISTS cleaned_outputs_fts;
+CREATE VIRTUAL TABLE cleaned_outputs_fts
+USING fts5(
+  document_id UNINDEXED,
+  run_id UNINDEXED,
+  text,
+  tokenize = 'porter unicode61'
+);
+INSERT INTO cleaned_outputs_fts (document_id, run_id, text)
+SELECT document_id, run_id, text FROM cleaned_outputs;
+
+DROP TABLE IF EXISTS raw_content_fts;
+CREATE VIRTUAL TABLE raw_content_fts
+USING fts5(
+  document_id UNINDEXED,
+  text,
+  tokenize = 'porter unicode61'
+);
+INSERT INTO raw_content_fts (document_id, text)
+SELECT substr(key, 5), text
+FROM content_blobs
+WHERE key LIKE 'raw:doc_%';

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -1043,7 +1043,20 @@ class SQLiteRepository:
             )
 
     def _save_chunks_sync(self, chunks: Sequence[Chunk]) -> None:
+        if not chunks:
+            return
+        document_ids = {str(chunk.document_id) for chunk in chunks}
         with self.database.connect() as connection:
+            # Replace the document's chunk set wholesale. Chunk ids hash the
+            # chunk text, so re-chunking (policy/engine change) produces new ids
+            # for the same (document_id, ordinal); a plain upsert on id then
+            # violates UNIQUE(document_id, ordinal). Deleting first also clears
+            # now-stale higher-ordinal chunks from a previously longer document.
+            placeholders = ",".join("?" for _ in document_ids)
+            connection.execute(
+                f"DELETE FROM chunks WHERE document_id IN ({placeholders})",  # noqa: S608
+                tuple(document_ids),
+            )
             connection.executemany(
                 """
                 INSERT INTO chunks (

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -179,11 +179,27 @@ class SQLiteDatabase:
             for migration in sorted(migration_root.iterdir(), key=lambda item: item.name):
                 if not migration.name.endswith(".sql") or migration.name in applied:
                     continue
-                connection.executescript(migration.read_text(encoding="utf-8"))
-                connection.execute(
-                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
-                    (migration.name, utc_now().isoformat()),
-                )
+                sql = migration.read_text(encoding="utf-8")
+                applied_at = utc_now().isoformat()
+                if "PRAGMA" in sql.upper():
+                    # Contains a PRAGMA (journal_mode / foreign_keys) that must
+                    # run outside a transaction (e.g. the 0003 table rebuild), so
+                    # it can't be wrapped; record the version right after.
+                    connection.executescript(sql)
+                    connection.execute(
+                        "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                        (migration.name, applied_at),
+                    )
+                else:
+                    # Apply the migration DDL and record its version in one
+                    # transaction so a crash can't leave a half-applied schema
+                    # with no version row (which would fail the next startup,
+                    # e.g. "duplicate column" on the ALTER TABLE migrations).
+                    # Trusted inputs: package filename + ISO timestamp (no quotes
+                    # possible), executed inside the migration's own transaction.
+                    insert = "INSERT INTO schema_migrations (version, applied_at) VALUES "
+                    version_row = f"{insert}('{migration.name}', '{applied_at}');"  # noqa: S608
+                    connection.executescript(f"BEGIN;\n{sql}\n{version_row}\nCOMMIT;")  # noqa: S608
 
     def connect(self) -> sqlite3.Connection:
         """Open a configured SQLite connection."""
@@ -421,6 +437,14 @@ class SQLiteRepository:
     async def save_document(self, document: Document) -> None:
         """Save a document."""
         await asyncio.to_thread(self._save_document_sync, document)
+
+    async def save_document_with_content(
+        self, document: Document, content_key: str, content_text: str
+    ) -> None:
+        """Persist a document and its raw text atomically (single transaction)."""
+        await asyncio.to_thread(
+            self._save_document_with_content_sync, document, content_key, content_text
+        )
 
     async def save_run(self, run: ProcessingRun) -> None:
         """Save a processing run."""
@@ -756,36 +780,70 @@ class SQLiteRepository:
                 yield message
             offset += len(messages)
 
+    @staticmethod
+    def _upsert_document(connection: sqlite3.Connection, document: Document) -> None:
+        connection.execute(
+            """
+            INSERT INTO documents (
+              id, source_path, filename, media_type, byte_size, sha256,
+              status, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+              source_path = excluded.source_path,
+              filename = excluded.filename,
+              media_type = excluded.media_type,
+              byte_size = excluded.byte_size,
+              sha256 = excluded.sha256,
+              status = excluded.status,
+              updated_at = excluded.updated_at
+            """,
+            (
+                str(document.id),
+                str(document.source.path),
+                document.source.filename,
+                document.source.media_type,
+                document.source.byte_size,
+                document.source.sha256,
+                document.status.value,
+                document.created_at.isoformat(),
+                document.updated_at.isoformat(),
+            ),
+        )
+
+    @staticmethod
+    def _upsert_text(connection: sqlite3.Connection, key: str, text: str) -> None:
+        connection.execute(
+            """
+            INSERT INTO content_blobs (key, text, created_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(key) DO UPDATE SET text = excluded.text
+            """,
+            (key, text, utc_now().isoformat()),
+        )
+        if key.startswith("raw:"):
+            document_id = key.removeprefix("raw:")
+            connection.execute(
+                "DELETE FROM raw_content_fts WHERE document_id = ?",
+                (document_id,),
+            )
+            connection.execute(
+                "INSERT INTO raw_content_fts (document_id, text) VALUES (?, ?)",
+                (document_id, text),
+            )
+
     def _save_document_sync(self, document: Document) -> None:
         with self.database.connect() as connection:
-            connection.execute(
-                """
-                INSERT INTO documents (
-                  id, source_path, filename, media_type, byte_size, sha256,
-                  status, created_at, updated_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                  source_path = excluded.source_path,
-                  filename = excluded.filename,
-                  media_type = excluded.media_type,
-                  byte_size = excluded.byte_size,
-                  sha256 = excluded.sha256,
-                  status = excluded.status,
-                  updated_at = excluded.updated_at
-                """,
-                (
-                    str(document.id),
-                    str(document.source.path),
-                    document.source.filename,
-                    document.source.media_type,
-                    document.source.byte_size,
-                    document.source.sha256,
-                    document.status.value,
-                    document.created_at.isoformat(),
-                    document.updated_at.isoformat(),
-                ),
-            )
+            self._upsert_document(connection, document)
+
+    def _save_document_with_content_sync(
+        self, document: Document, content_key: str, content_text: str
+    ) -> None:
+        # One transaction: a crash must not leave a document row without its raw
+        # text (which breaks processing with a KeyError) or vice versa.
+        with self.database.connect() as connection:
+            self._upsert_document(connection, document)
+            self._upsert_text(connection, content_key, content_text)
 
     def _get_document_sync(self, document_id: DocumentId) -> Document | None:
         with self.database.connect() as connection:
@@ -977,27 +1035,7 @@ class SQLiteRepository:
 
     def _put_text_sync(self, key: str, text: str) -> None:
         with self.database.connect() as connection:
-            connection.execute(
-                """
-                INSERT INTO content_blobs (key, text, created_at)
-                VALUES (?, ?, ?)
-                ON CONFLICT(key) DO UPDATE SET text = excluded.text
-                """,
-                (key, text, utc_now().isoformat()),
-            )
-            if key.startswith("raw:"):
-                document_id = key.removeprefix("raw:")
-                connection.execute(
-                    "DELETE FROM raw_content_fts WHERE document_id = ?",
-                    (document_id,),
-                )
-                connection.execute(
-                    """
-                    INSERT INTO raw_content_fts (document_id, text)
-                    VALUES (?, ?)
-                    """,
-                    (document_id, text),
-                )
+            self._upsert_text(connection, key, text)
 
     def _get_text_sync(self, key: str) -> str:
         with self.database.connect() as connection:

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -1021,7 +1021,7 @@ class SQLiteRepository:
                 UPDATE runs
                 SET status = ?, stage = ?, completed_chunks = ?, failed_chunks = ?, updated_at = ?
                 WHERE id = ?
-                  AND status != 'canceled'
+                  AND status NOT IN ('canceled', 'succeeded', 'failed')
                 """,
                 (
                     status.value,

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -519,6 +519,16 @@ class SQLiteRepository:
         """Delete a document and dependent records."""
         await asyncio.to_thread(self._delete_document_sync, document_id)
 
+    async def fail_interrupted_runs(self, *, error: str) -> int:
+        """Fail runs left RUNNING by a crashed in-process worker.
+
+        An in-process run has no durable lease, so a row still marked RUNNING at
+        startup belongs to a process that died mid-run. Mark it FAILED (and its
+        document FAILED if still PROCESSING) so it can be retried instead of
+        appearing active forever. Returns the number of runs reconciled.
+        """
+        return await asyncio.to_thread(self._fail_interrupted_runs_sync, error)
+
     async def update_status(
         self,
         run_id: RunId,
@@ -1002,6 +1012,33 @@ class SQLiteRepository:
                 (limit, offset),
             ).fetchall()
         return [_run_from_row(row) for row in rows]
+
+    def _fail_interrupted_runs_sync(self, error: str) -> int:
+        with self.database.connect() as connection:
+            rows = connection.execute(
+                "SELECT id, document_id FROM runs WHERE status = 'running'"
+            ).fetchall()
+            if not rows:
+                return 0
+            now = utc_now().isoformat()
+            connection.execute(
+                """
+                UPDATE runs
+                SET status = 'failed', stage = 'complete', error = ?, updated_at = ?
+                WHERE status = 'running'
+                """,
+                (error, now),
+            )
+            for document_id in {row["document_id"] for row in rows}:
+                connection.execute(
+                    """
+                    UPDATE documents
+                    SET status = 'failed', updated_at = ?
+                    WHERE id = ? AND status = 'processing'
+                    """,
+                    (now, document_id),
+                )
+        return len(rows)
 
     def _update_run_status_sync(
         self,

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -143,6 +143,16 @@ class SQLiteDatabase:
         """Run lightweight SQLite maintenance for long-lived local databases."""
         return await asyncio.to_thread(self._maintain_sync, vacuum)
 
+    async def prune_caches(self, *, older_than_days: int) -> dict[str, int]:
+        """Delete content-addressed cache rows older than the retention window.
+
+        The extraction and cleaned-chunk caches are keyed by content hash, so
+        they grow without bound as documents come and go. Pruning by age keeps
+        them from accumulating stale entries no live document will ever reuse.
+        Returns the number of rows removed per table.
+        """
+        return await asyncio.to_thread(self._prune_caches_sync, older_than_days)
+
     async def stats(self) -> SQLiteStorageStats:
         """Return SQLite file, page, row, and stored-text sizing statistics."""
         return await asyncio.to_thread(self._stats_sync)
@@ -232,6 +242,20 @@ class SQLiteDatabase:
             checkpoint_checkpointed_frames=int(row[2]),
             vacuumed=vacuum,
         )
+
+    def _prune_caches_sync(self, older_than_days: int) -> dict[str, int]:
+        if older_than_days < 0:
+            raise ValueError("older_than_days must be non-negative")
+        cutoff = (utc_now() - timedelta(days=older_than_days)).isoformat()
+        removed: dict[str, int] = {}
+        with self.connect() as connection:
+            for table in ("extraction_cache", "cleaned_chunk_cache"):
+                cursor = connection.execute(
+                    f"DELETE FROM {table} WHERE created_at < ?",  # noqa: S608 - fixed table names
+                    (cutoff,),
+                )
+                removed[table] = max(cursor.rowcount, 0)
+        return removed
 
     def _stats_sync(self) -> SQLiteStorageStats:
         self.path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/librarian/storage/sqlite.py
+++ b/src/librarian/storage/sqlite.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from importlib.resources import files
 from pathlib import Path
-from typing import TYPE_CHECKING, LiteralString, cast
+from typing import TYPE_CHECKING, Any, LiteralString, cast
 
 from librarian.application.clean_chunks import CleanedChunk
 from librarian.application.jobs import QueuedRun, QueueStatus
@@ -1227,29 +1227,33 @@ class SQLiteRepository:
             return []
 
         by_sha = {chunk.sha256: chunk for chunk in chunks}
+        shas = list(by_sha)
+        # Batch the lookups into a few IN-clause queries instead of one query
+        # per chunk. Cap each batch well under SQLite's default 999-variable
+        # limit, leaving room for the three shared filter parameters.
+        batch_size = 400
+        rows_by_sha: dict[str, Any] = {}
         with self.database.connect() as connection:
-            rows = [
-                row
-                for sha in by_sha
-                if (
-                    row := connection.execute(
-                        """
-                        SELECT chunk_sha256, text, warnings
-                        FROM cleaned_chunk_cache
-                        WHERE chunk_sha256 = ?
-                          AND prompt_version = ?
-                          AND model_provider = ?
-                          AND model_name = ?
-                        """,
-                        (sha, prompt_version, model_provider, model_name),
-                    ).fetchone()
+            for start in range(0, len(shas), batch_size):
+                batch = shas[start : start + batch_size]
+                placeholders = ",".join("?" * len(batch))
+                select_clause = (
+                    "SELECT chunk_sha256, text, warnings FROM cleaned_chunk_cache "
+                    "WHERE prompt_version = ? AND model_provider = ? AND model_name = ? "
+                    "AND chunk_sha256 IN ("
                 )
-                is not None
-            ]
+                query = f"{select_clause}{placeholders})"  # noqa: S608 - only ? placeholders
+                for row in connection.execute(
+                    query,
+                    (prompt_version, model_provider, model_name, *batch),
+                ).fetchall():
+                    rows_by_sha[str(row["chunk_sha256"])] = row
 
         cached: list[CleanedChunk] = []
-        for row in rows:
-            chunk = by_sha[str(row["chunk_sha256"])]
+        for sha, chunk in by_sha.items():
+            row = rows_by_sha.get(sha)
+            if row is None:
+                continue
             warnings = tuple(str(item) for item in json.loads(str(row["warnings"])))
             cached.append(
                 CleanedChunk(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from librarian.ingest import extractors
+
+
+@pytest.fixture(autouse=True)
+def _reset_page_manifest_context() -> Iterator[None]:
+    """Reset the page-manifest ContextVar between tests.
+
+    The extractor stores the current extraction's page-manifest path in a
+    ContextVar (so concurrent conversions stay isolated). Tests that call
+    ``set_page_manifest_path`` synchronously mutate the test process's own
+    context, which would otherwise leak into unrelated tests. Production code
+    runs each conversion in its own asyncio task context and also sets the
+    value explicitly per conversion, so this only guards test isolation.
+    """
+    extractors.reset_page_manifest_path()
+    try:
+        yield
+    finally:
+        extractors.reset_page_manifest_path()

--- a/tests/test_api_processing.py
+++ b/tests/test_api_processing.py
@@ -1429,7 +1429,7 @@ def test_api_config_exposes_operational_controls(tmp_path: Path) -> None:
     assert payload["ocr_threshold"] == 160
     assert payload["ocr_preserve_page_images"] is True
     assert payload["ocr_rotation_retry"] is True
-    assert payload["cleaning_prompt_version"] == "cmos_v2"
+    assert payload["cleaning_prompt_version"] == "cmos_v3"
     assert payload["classification_prompt_version"] == "dewey_v5"
     assert payload["universal_timeout_seconds"] == 77
     assert payload["llm_max_retries"] == settings.llm_max_retries

--- a/tests/test_api_processing.py
+++ b/tests/test_api_processing.py
@@ -665,6 +665,33 @@ def test_api_rate_limit_uses_x_forwarded_for_from_trusted_proxy(tmp_path: Path) 
     assert limited.json()["code"] == "rate_limited"
 
 
+def test_api_rate_limit_uses_rightmost_untrusted_forwarded_hop(tmp_path: Path) -> None:
+    # Two proxies in front: the real client is the rightmost non-proxy hop
+    # (appended by our own trusted proxy). A spoofed leftmost value must be
+    # ignored so an attacker cannot dodge or forge another client's rate bucket.
+    settings = Settings(
+        data_dir=tmp_path / ".librarian",
+        database_path=tmp_path / ".librarian" / "librarian.sqlite",
+        api_rate_limit_per_minute=1,
+        api_trusted_proxy_cidrs="10.0.0.0/24",
+    )
+    with TestClient(create_app(settings), client=("10.0.0.5", 50000)) as client:
+        # Real client 198.51.100.1 behind a trusted inner proxy 10.0.0.9.
+        first = client.get(
+            "/documents",
+            headers={"x-forwarded-for": "198.51.100.1, 10.0.0.9"},
+        )
+        # Attacker spoofs a different leftmost value but is the same real client;
+        # the rightmost untrusted hop is still 198.51.100.1, so it is limited.
+        limited = client.get(
+            "/documents",
+            headers={"x-forwarded-for": "203.0.113.7, 198.51.100.1, 10.0.0.9"},
+        )
+
+    assert first.status_code == 200
+    assert limited.status_code == 429
+
+
 def test_api_audit_ignores_untrusted_x_forwarded_for(tmp_path: Path) -> None:
     settings = Settings(
         data_dir=tmp_path / ".librarian",

--- a/tests/test_audit_lifecycle.py
+++ b/tests/test_audit_lifecycle.py
@@ -1,0 +1,152 @@
+"""Regression tests for Tier 2 run-lifecycle and streaming fixes."""
+
+# These tests intentionally exercise internal helpers (SSE framing, the worker
+# fan-out, the event-stream drain loop) that carry no public wrapper.
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+import librarian.api.app as api_app
+from librarian.api.app import _sse_data_frame, _stream_run_events
+from librarian.application.clean_chunks import _run_workers
+from librarian.application.jobs import QueueWorker
+from librarian.domain.models import RunStatus
+
+
+def test_sse_data_frame_splits_embedded_newlines() -> None:
+    # A raw newline in a data: payload would terminate the SSE event early;
+    # each line must become its own data: field.
+    frame = _sse_data_frame("line one\nline two")
+    assert frame == "data: line one\ndata: line two\n\n"
+
+
+def test_sse_data_frame_single_line() -> None:
+    assert _sse_data_frame("hello") == "data: hello\n\n"
+
+
+@pytest.mark.asyncio
+async def test_run_workers_cancels_siblings_on_first_failure() -> None:
+    started = 0
+    cancelled = 0
+
+    async def worker() -> None:
+        nonlocal started, cancelled
+        index = started
+        started += 1
+        if index == 0:
+            # First worker fails fast.
+            raise ValueError("boom")
+        try:
+            # Siblings would otherwise keep running; they must be cancelled.
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancelled += 1
+            raise
+
+    with pytest.raises(ValueError, match="boom"):
+        await _run_workers(worker, worker_count=3)
+
+    # The original exception type propagates unwrapped (no ExceptionGroup),
+    # and the two still-running siblings were cancelled rather than orphaned.
+    assert cancelled == 2
+
+
+@pytest.mark.asyncio
+async def test_run_workers_completes_when_all_succeed() -> None:
+    completed = 0
+
+    async def worker() -> None:
+        nonlocal completed
+        completed += 1
+
+    await _run_workers(worker, worker_count=4)
+    assert completed == 4
+
+
+@pytest.mark.asyncio
+async def test_run_forever_survives_transient_claim_error() -> None:
+    calls = 0
+
+    class FlakyQueue:
+        async def claim(self, *, worker_id: str, lease_seconds: int) -> None:
+            nonlocal calls
+            del worker_id, lease_seconds
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("transient DB error")
+            # Second poll: signal the loop to stop and report no work.
+            worker.stop()
+            return None
+
+    async def processor(run_id: object) -> object:
+        del run_id
+        return None
+
+    worker = QueueWorker(
+        queue=FlakyQueue(),  # type: ignore[arg-type]
+        processor=processor,
+        worker_id="w1",
+        poll_interval_seconds=0.0,
+    )
+
+    # A transient error in the first claim must not kill the worker loop; it
+    # backs off and polls again, at which point we stop it.
+    await asyncio.wait_for(worker.run_forever(), timeout=2.0)
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_event_stream_drains_tail_events_after_terminal_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _TerminalRun:
+        status = RunStatus.SUCCEEDED
+
+    class _Repo:
+        def __init__(self) -> None:
+            # e1 is visible on the first poll; e2 lands after the run is already
+            # terminal (the pipeline emits its final "complete" event *after*
+            # writing the terminal status), so only the drain can recover it.
+            self._events = ["e1", "e2-after-terminal"]
+
+        async def list_events(self, offset: int) -> list[str]:
+            return self._events[offset:]
+
+        async def get_run(self, run_id: object) -> _TerminalRun:
+            del run_id
+            return _TerminalRun()
+
+    repo = _Repo()
+
+    class _Container:
+        repository = repo
+
+    async def _fake_container(settings: object) -> _Container:
+        del settings
+        return _Container()
+
+    async def fetch_frames(container: Any, offset: int) -> list[str]:
+        del container
+        events = await repo.list_events(offset)
+        return [_sse_data_frame(event) for event in events]
+
+    monkeypatch.setattr(api_app, "build_ingest_container", _fake_container)
+
+    frames = [
+        frame
+        async for frame in _stream_run_events(
+            settings=cast("Any", None),
+            run_id=cast("Any", "run_x"),
+            fetch_frames=fetch_frames,
+        )
+    ]
+
+    joined = "".join(frames)
+    assert "data: e1" in joined
+    assert "data: e2-after-terminal" in joined
+    assert joined.endswith("event: done\ndata: done\n\n")

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -2,7 +2,10 @@ import json
 
 import pytest
 
-from librarian.application.classify_document import ClassifyDocument
+from librarian.application.classify_document import (
+    ClassifyDocument,
+    _classification_sample,  # pyright: ignore[reportPrivateUsage]
+)
 from librarian.domain.ids import DocumentId
 from librarian.llm.mock import MockLLMProvider
 from librarian.prompts import PromptCatalog
@@ -38,6 +41,22 @@ def _classifier(provider: MockLLMProvider | _CannedProvider) -> ClassifyDocument
         model="mock-cleaner",
         taxonomy=DeweyTaxonomy(),
     )
+
+
+def test_classification_sample_uses_whole_text_when_short() -> None:
+    assert _classification_sample("brief report", budget=8_000) == "brief report"
+
+
+def test_classification_sample_covers_head_middle_tail_for_long_text() -> None:
+    text = "H" * 5_000 + "M" * 5_000 + "T" * 5_000
+    sample = _classification_sample(text, budget=900)
+
+    # A long document must not be classified on its opening pages alone.
+    assert sample.startswith("H")
+    assert sample.endswith("T")
+    assert "M" in sample
+    assert "[...]" in sample
+    assert len(sample) < len(text)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,24 @@ def test_cli_read_only_commands_do_not_require_llm_credentials(tmp_path: Path) -
     assert "Missing API key" not in show.output + status.output + export.output
 
 
+def test_cli_admin_config_prints_redacted_settings(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = {
+        "LIBRARIAN_DATA_DIR": str(tmp_path / ".librarian"),
+        "LIBRARIAN_DATABASE_PATH": str(tmp_path / ".librarian" / "librarian.sqlite"),
+        "LIBRARIAN_API_KEY": "top-secret-key",
+    }
+
+    result = runner.invoke(app, ["admin", "config", "--json"], env=env)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["api_key"] == "***redacted***"
+    assert "top-secret-key" not in result.stdout
+    assert payload["pdf_engine"] == "auto"
+    assert payload["figure_vision_enabled"] is False
+
+
 def test_cli_doctor_reports_optional_dependency_status(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,48 @@ def test_cli_read_only_commands_do_not_require_llm_credentials(tmp_path: Path) -
     assert "Missing API key" not in show.output + status.output + export.output
 
 
+def test_cli_agent_json_surfaces_round_trip(tmp_path: Path) -> None:
+    """Agents drive imports and monitor runs via --json; lock those surfaces."""
+    runner = CliRunner()
+    source_dir = tmp_path / "docs"
+    source_dir.mkdir()
+    (source_dir / "note.txt").write_text("Racehorse conditioning notes for the spring meet.")
+    env = {
+        "LIBRARIAN_DATA_DIR": str(tmp_path / ".librarian"),
+        "LIBRARIAN_DATABASE_PATH": str(tmp_path / ".librarian" / "librarian.sqlite"),
+        "LIBRARIAN_LLM_PROVIDER": "mock",
+    }
+
+    version = runner.invoke(app, ["version", "--json"], env=env)
+    assert version.exit_code == 0
+    assert json.loads(version.stdout)["version"]
+
+    imported = runner.invoke(app, ["import", str(source_dir), "--process", "--json"], env=env)
+    assert imported.exit_code == 0
+    report = json.loads(imported.stdout)
+    assert report["summary"]["processed"] == 1
+    run_id = report["items"][0]["run_id"]
+
+    runs = runner.invoke(app, ["admin", "runs", "--json"], env=env)
+    assert runs.exit_code == 0
+    run_records = json.loads(runs.stdout)["runs"]
+    assert run_records[0]["id"] == run_id
+    assert run_records[0]["status"] == "succeeded"
+
+    queue = runner.invoke(app, ["admin", "queue", "--json"], env=env)
+    assert queue.exit_code == 0
+    assert json.loads(queue.stdout) == {"queue": []}
+
+    converted = runner.invoke(app, ["convert-dir", str(source_dir), "--json"], env=env)
+    assert converted.exit_code == 0
+    conversion = json.loads(converted.stdout)
+    assert conversion["summary"]["converted"] == 1
+    # Sidecars are always written now (they mark outputs as librarian
+    # artifacts so re-runs skip them); the deprecated flag is a no-op.
+    output_path = Path(conversion["items"][0]["output_path"])
+    assert output_path.with_suffix(output_path.suffix + ".json").exists()
+
+
 def test_cli_admin_config_prints_redacted_settings(tmp_path: Path) -> None:
     runner = CliRunner()
     env = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,7 +59,7 @@ def test_settings_reject_invalid_runtime_controls(kwargs: dict[str, Any]) -> Non
 def test_settings_default_prompt_stack() -> None:
     settings = Settings()
 
-    assert settings.cleaning_prompt_version == "cmos_v2"
+    assert settings.cleaning_prompt_version == "cmos_v3"
     assert settings.classification_prompt_version == "dewey_v5"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,11 +49,31 @@ from librarian.config import Settings
         {"llm_completion_cost_per_1k_tokens_usd": -0.01},
         {"llm_max_prompt_chars": 0},
         {"llm_max_response_chars": 0},
+        {"figure_vision_min_bytes": 9000, "figure_vision_max_bytes": 8000},
     ],
 )
 def test_settings_reject_invalid_runtime_controls(kwargs: dict[str, Any]) -> None:
     with pytest.raises(ValidationError):
         Settings(**kwargs)
+
+
+def test_redacted_config_masks_secrets_and_exposes_settings() -> None:
+    settings = Settings(
+        api_key="raw-secret",
+        api_key_hashes="hash-secret",
+        otel_headers="authorization=Bearer tok",
+    )
+
+    payload = settings.redacted_config()
+
+    assert payload["api_key"] == "***redacted***"
+    assert payload["api_key_hashes"] == "***redacted***"
+    assert payload["otel_headers"] == "***redacted***"
+    # Non-secret operational settings remain visible.
+    assert payload["pdf_engine"] == "auto"
+    assert payload["figure_vision_enabled"] is False
+    # A secret left unset stays null rather than being masked.
+    assert payload["api_keys"] is None
 
 
 def test_settings_default_prompt_stack() -> None:

--- a/tests/test_corpus_eval.py
+++ b/tests/test_corpus_eval.py
@@ -74,7 +74,7 @@ async def test_corpus_eval_runs_conversion_processing_and_search(tmp_path: Path)
     assert rendered["librarian_version"]
     assert rendered["llm_provider"] == "mock"
     assert rendered["llm_model"] == "mock-cleaner"
-    assert rendered["cleaning_prompt_version"] == "cmos_v2"
+    assert rendered["cleaning_prompt_version"] == "cmos_v3"
     assert rendered["classification_prompt_version"] == "dewey_v5"
     assert rendered["generated_at"].endswith("+00:00")
     assert rendered["summary"]["case_count"] == 1

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -49,7 +49,7 @@ async def test_eval_suite_runs_against_configured_stack(tmp_path: Path) -> None:
     assert rendered["evidence_tier"] == "mock-smoke"
     assert rendered["librarian_version"]
     assert rendered["generated_at"].endswith("+00:00")
-    assert rendered["cleaning_prompt_version"] == "cmos_v2"
+    assert rendered["cleaning_prompt_version"] == "cmos_v3"
     assert rendered["classification_prompt_version"] == "dewey_v5"
     assert rendered["summary"]["case_count"] == 1
     assert rendered["summary"]["passed_count"] == 1

--- a/tests/test_extraction_cache.py
+++ b/tests/test_extraction_cache.py
@@ -117,7 +117,10 @@ def test_caching_extractor_does_not_cache_failures(tmp_path: Path) -> None:
     assert inner.calls == 2
 
 
-def test_caching_extractor_bypasses_cache_when_manifest_active(tmp_path: Path) -> None:
+def test_caching_extractor_caches_even_with_manifest_active(tmp_path: Path) -> None:
+    # The cache now composes with the page-manifest/sidecar flow: the first
+    # extract populates the cache (running the real extraction with the manifest
+    # active) and the second is served from cache, so re-imports skip work.
     source = _write(tmp_path, "doc.txt", b"hello world")
     inner = _CountingExtractor()
     cache = _InMemoryCache()
@@ -127,8 +130,8 @@ def test_caching_extractor_bypasses_cache_when_manifest_active(tmp_path: Path) -
     asyncio.run(extractor.extract(source))
     asyncio.run(extractor.extract(source))
 
-    assert inner.calls == 2  # cache bypassed while a manifest is requested
-    assert cache.entries == {}
+    assert inner.calls == 1  # second extraction served from cache
+    assert cache.entries != {}
 
 
 def test_extraction_config_signature_is_stable_and_sensitive() -> None:

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -262,6 +262,26 @@ async def test_docx_extractor_preserves_list_markers(tmp_path: Path) -> None:
     assert "1. Numbered item" in text
 
 
+@pytest.mark.asyncio
+async def test_docx_extractor_preserves_body_order_of_mixed_content(tmp_path: Path) -> None:
+    from docx import Document
+
+    path = tmp_path / "fixture.docx"
+    document = Document()
+    document.add_paragraph("FIRST paragraph")
+    table = document.add_table(rows=1, cols=2)
+    table.cell(0, 0).text = "cell a"
+    table.cell(0, 1).text = "cell b"
+    document.add_paragraph("LAST paragraph")
+    document.save(str(path))
+
+    text = await CompositeExtractor().extract(path)
+
+    # The table sits between the two paragraphs in the source; it must stay
+    # there rather than being hoisted to the end of the document.
+    assert text.index("FIRST") < text.index("cell a | cell b") < text.index("LAST")
+
+
 @pytest.mark.skipif(shutil.which("tesseract") is None, reason="tesseract not installed")
 @pytest.mark.asyncio
 async def test_image_ocr_extractor_reads_fixture(tmp_path: Path) -> None:
@@ -1509,6 +1529,7 @@ async def test_pdf_extractor_passes_ocr_preprocessing_options(
         "ocr_threshold": 155,
         "ocr_preserve_page_images": False,
         "ocr_rotation_retry": False,
+        "ocr_auto_orient": True,
         "ocr_correction_mode": "never",
         "ocr_correction_model": "mock-cleaner",
         "ocr_low_confidence_threshold": 85.0,

--- a/tests/test_liteparse_extractor.py
+++ b/tests/test_liteparse_extractor.py
@@ -183,7 +183,11 @@ def test_fallback_extractor_uses_legacy_on_primary_failure(tmp_path: Path) -> No
     result = asyncio.run(fallback.extract(tmp_path / "x.pdf"))
 
     assert result == "legacy extracted text"
-    assert fallback.last_metadata == {"engine": "legacy"}
+    # The downgrade is recorded so a permanently broken primary is diagnosable.
+    assert fallback.last_metadata is not None
+    assert fallback.last_metadata["engine"] == "legacy"
+    assert fallback.last_metadata["fallback_from_primary"] is True
+    assert "engine unavailable" in str(fallback.last_metadata["primary_error"])
 
 
 def _text_image_png(tmp_path: Path, *, rotate: int = 0) -> Path:

--- a/tests/test_liteparse_extractor.py
+++ b/tests/test_liteparse_extractor.py
@@ -190,16 +190,38 @@ def test_fallback_extractor_uses_legacy_on_primary_failure(tmp_path: Path) -> No
     assert "engine unavailable" in str(fallback.last_metadata["primary_error"])
 
 
+def _fixture_font(size: int):
+    """A real scalable font on any OS.
+
+    Pillow's tiny bitmap fallback renders text too small for Tesseract's
+    orientation detection (macOS runners have no DejaVu at the Linux path).
+    """
+    from PIL import ImageFont
+
+    for candidate in (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",  # Linux
+        "/System/Library/Fonts/Supplemental/Arial.ttf",  # macOS
+        "/System/Library/Fonts/Helvetica.ttc",  # macOS
+        "C:/Windows/Fonts/arial.ttf",  # Windows
+    ):
+        try:
+            return ImageFont.truetype(candidate, size)
+        except OSError:
+            continue
+    try:
+        # Pillow >= 10.1 renders its default font at any size.
+        return ImageFont.load_default(size=size)
+    except TypeError:  # pragma: no cover - ancient Pillow only
+        return ImageFont.load_default()
+
+
 def _text_image_png(tmp_path: Path, *, rotate: int = 0) -> Path:
     image_module = pytest.importorskip("PIL.Image")
-    from PIL import ImageDraw, ImageFont
+    from PIL import ImageDraw
 
     image = image_module.new("RGB", (820, 300), "white")
     draw = ImageDraw.Draw(image)
-    try:
-        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 30)
-    except OSError:
-        font = ImageFont.load_default()
+    font = _fixture_font(30)
     for index, line in enumerate(
         ["The annual report summarizes revenue", "and dividend policy for shareholders."]
     ):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -180,6 +180,37 @@ def test_redact_secrets_handles_single_quoted_secret_fields() -> None:
     assert "'pass'" not in message
 
 
+def test_redact_secrets_masks_url_credentials() -> None:
+    message = redact_secrets("connect postgres://admin:hunter2@db.internal:5432/lib failed")
+
+    assert "hunter2" not in message
+    assert "postgres://admin:[REDACTED]@db.internal:5432/lib" in message
+
+
+def test_redact_secrets_leaves_credential_free_urls_untouched() -> None:
+    assert redact_secrets("GET https://example.com/api/v1") == "GET https://example.com/api/v1"
+
+
+def test_redact_secrets_masks_bearer_tokens_without_header_name() -> None:
+    message = redact_secrets("retry with Bearer abcDEF1234567890tokenvalue")
+
+    assert "abcDEF1234567890tokenvalue" not in message
+    assert "Bearer [REDACTED]" in message
+
+
+def test_redact_secrets_masks_provider_specific_tokens() -> None:
+    secrets = [
+        "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+        "xoxb-1234567890-ABCDEFghij",
+        "AKIAIOSFODNN7EXAMPLE",
+        "AIzaSyA1234567890abcdefghijklmnopqrstuvw",
+    ]
+    for secret in secrets:
+        message = redact_secrets(f"leaked {secret} in logs")
+        assert secret not in message, secret
+        assert "[REDACTED]" in message
+
+
 def test_sanitize_error_message_redacts_and_truncates() -> None:
     message = sanitize_error_message(
         "provider failed api_key=abc123 " + ("private transcript text " * 20),

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -187,8 +187,18 @@ def test_redact_secrets_masks_url_credentials() -> None:
     assert "postgres://admin:[REDACTED]@db.internal:5432/lib" in message
 
 
+def test_redact_secrets_masks_url_password_without_username() -> None:
+    # DSNs commonly omit the username: redis://:password@host.
+    message = redact_secrets("connect redis://:s3cr3tpass@localhost:6379/0")
+
+    assert "s3cr3tpass" not in message
+    assert "redis://:[REDACTED]@localhost:6379/0" in message
+
+
 def test_redact_secrets_leaves_credential_free_urls_untouched() -> None:
     assert redact_secrets("GET https://example.com/api/v1") == "GET https://example.com/api/v1"
+    # A colon in the path (not credentials) must not trigger redaction.
+    assert redact_secrets("see http://example.com/a:b") == "see http://example.com/a:b"
 
 
 def test_redact_secrets_masks_bearer_tokens_without_header_name() -> None:

--- a/tests/test_ocr_orientation.py
+++ b/tests/test_ocr_orientation.py
@@ -118,16 +118,39 @@ def _osd_functional() -> bool:
     return "osd" in (result.stdout + result.stderr)
 
 
+def _fixture_font(size: int):
+    """A real scalable font on any OS.
+
+    Falling back to Pillow's tiny bitmap default renders text too small for
+    Tesseract's orientation detection to work, which made these tests fail on
+    macOS runners (no DejaVu at the Linux path) while passing on Linux.
+    """
+    from PIL import ImageFont
+
+    for candidate in (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",  # Linux
+        "/System/Library/Fonts/Supplemental/Arial.ttf",  # macOS
+        "/System/Library/Fonts/Helvetica.ttc",  # macOS
+        "C:/Windows/Fonts/arial.ttf",  # Windows
+    ):
+        try:
+            return ImageFont.truetype(candidate, size)
+        except OSError:
+            continue
+    try:
+        # Pillow >= 10.1 renders its default font at any size.
+        return ImageFont.load_default(size=size)
+    except TypeError:  # pragma: no cover - ancient Pillow only
+        return ImageFont.load_default()
+
+
 def _document_image(tmp_path: Path, *, rotate: int):
     image_module = pytest.importorskip("PIL.Image")
-    from PIL import ImageDraw, ImageFont
+    from PIL import ImageDraw
 
     image = image_module.new("RGB", (900, 420), "white")
     draw = ImageDraw.Draw(image)
-    try:
-        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 30)
-    except OSError:
-        font = ImageFont.load_default()
+    font = _fixture_font(30)
     lines = [
         "The quarterly revenue report shows strong growth",
         "across every region this fiscal year.",

--- a/tests/test_parent_watch.py
+++ b/tests/test_parent_watch.py
@@ -1,0 +1,61 @@
+"""Tests for the parent-process death watcher."""
+
+# The termination hook is internal; the test swaps it to observe the watcher.
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import os
+import threading
+
+import librarian.runtime.parent_watch as watch_module
+from librarian.runtime.parent_watch import (
+    PARENT_PID_ENV,
+    parent_pid_from_env,
+    process_alive,
+    start_parent_death_watcher,
+)
+
+
+def test_parent_pid_from_env_parses_valid_pid() -> None:
+    assert parent_pid_from_env({PARENT_PID_ENV: "4242"}) == 4242
+
+
+def test_parent_pid_from_env_rejects_missing_invalid_and_init() -> None:
+    assert parent_pid_from_env({}) is None
+    assert parent_pid_from_env({PARENT_PID_ENV: ""}) is None
+    assert parent_pid_from_env({PARENT_PID_ENV: "not-a-number"}) is None
+    # PID 1 (init/launchd) and non-positive PIDs are not watchable parents.
+    assert parent_pid_from_env({PARENT_PID_ENV: "1"}) is None
+    assert parent_pid_from_env({PARENT_PID_ENV: "0"}) is None
+
+
+def test_process_alive_reports_self_and_missing() -> None:
+    assert process_alive(os.getpid()) is True
+    # PID 2**31 - 1 is effectively guaranteed not to exist.
+    assert process_alive(2**31 - 1) is False
+
+
+def test_start_parent_death_watcher_no_env_returns_none() -> None:
+    assert start_parent_death_watcher(env={}) is None
+
+
+def test_start_parent_death_watcher_terminates_when_parent_gone() -> None:
+    # Fork a child that exits immediately, then watch it as the "parent".
+    child_pid = os.fork()
+    if child_pid == 0:  # pragma: no cover - runs only in the forked child
+        os._exit(0)
+
+    terminated = threading.Event()
+    original = watch_module._terminate_self
+    watch_module._terminate_self = terminated.set
+    try:
+        os.waitpid(child_pid, 0)  # reap so the PID is truly gone
+        thread = start_parent_death_watcher(
+            poll_interval_seconds=0.01,
+            env={PARENT_PID_ENV: str(child_pid)},
+        )
+        assert thread is not None
+        assert terminated.wait(timeout=2.0), "watcher did not react to dead parent"
+    finally:
+        watch_module._terminate_self = original

--- a/tests/test_provider_integration.py
+++ b/tests/test_provider_integration.py
@@ -86,7 +86,7 @@ async def test_real_provider_shipped_v2_eval_suite(tmp_path: Path) -> None:
 
     assert result.passed
     assert result.provider == "openai-compatible"
-    assert result.cleaning_prompt_version == "cmos_v2"
+    assert result.cleaning_prompt_version == "cmos_v3"
     assert result.classification_prompt_version == "dewey_v5"
 
 

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -60,6 +60,43 @@ class FakeTracer:
 
 
 @pytest.mark.asyncio
+async def test_prune_caches_removes_only_stale_rows(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "librarian.sqlite")
+    await database.initialize()
+
+    old = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+    fresh = datetime.now(UTC).isoformat()
+    with database.connect() as connection:
+        connection.execute(
+            "INSERT INTO extraction_cache "
+            "(content_sha256, config_signature, source_extension, text, created_at) "
+            "VALUES ('stale', 'cfg', '.pdf', 't', ?)",
+            (old,),
+        )
+        connection.execute(
+            "INSERT INTO extraction_cache "
+            "(content_sha256, config_signature, source_extension, text, created_at) "
+            "VALUES ('fresh', 'cfg', '.pdf', 't', ?)",
+            (fresh,),
+        )
+        connection.execute(
+            "INSERT INTO cleaned_chunk_cache (chunk_sha256, prompt_version, "
+            "model_provider, model_name, text, warnings, created_at) "
+            "VALUES ('stale', 'v', 'p', 'm', 't', '[]', ?)",
+            (old,),
+        )
+
+    removed = await database.prune_caches(older_than_days=30)
+
+    assert removed == {"extraction_cache": 1, "cleaned_chunk_cache": 1}
+    with database.connect() as connection:
+        remaining = connection.execute(
+            "SELECT content_sha256 FROM extraction_cache"
+        ).fetchall()
+    assert [row["content_sha256"] for row in remaining] == ["fresh"]
+
+
+@pytest.mark.asyncio
 async def test_sqlite_initializes_schema(tmp_path: Path) -> None:
     database_path = tmp_path / "librarian.sqlite"
     database = SQLiteDatabase(database_path)

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -16,6 +16,7 @@ from librarian.domain.models import (
     Classification,
     Document,
     DocumentStatus,
+    ProcessingRun,
     RunStage,
     RunStatus,
     SourceFile,
@@ -126,6 +127,46 @@ async def test_sqlite_initializes_schema(tmp_path: Path) -> None:
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
     assert synchronous == 1
+
+
+@pytest.mark.asyncio
+async def test_fail_interrupted_runs_reconciles_orphaned_running_runs(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "librarian.sqlite")
+    await database.initialize()
+    repository = SQLiteRepository(database)
+    document = Document(
+        id=DocumentId("doc_orphan"),
+        source=SourceFile(
+            path=tmp_path / "o.pdf",
+            filename="o.pdf",
+            media_type="application/pdf",
+            byte_size=1,
+            sha256="orphan-sha",
+        ),
+        status=DocumentStatus.PROCESSING,
+    )
+    await repository.save_document(document)
+    await repository.save_run(
+        ProcessingRun(
+            id=RunId("run_orphan"),
+            document_id=document.id,
+            status=RunStatus.RUNNING,
+            stage=RunStage.CLEAN,
+        )
+    )
+
+    reconciled = await repository.fail_interrupted_runs(error="interrupted by server restart")
+
+    assert reconciled == 1
+    run = await repository.get_run(RunId("run_orphan"))
+    assert run is not None
+    assert run.status == RunStatus.FAILED
+    assert run.error == "interrupted by server restart"
+    document_after = await repository.get_document(document.id)
+    assert document_after is not None
+    assert document_after.status == DocumentStatus.FAILED
+    # A second pass is a no-op once nothing is left RUNNING.
+    assert await repository.fail_interrupted_runs(error="x") == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -83,6 +83,8 @@ async def test_sqlite_initializes_schema(tmp_path: Path) -> None:
         "0007_classification_description.sql",
         "0008_classification_series.sql",
         "0009_extraction_cache.sql",
+        "0010_performance_indexes.sql",
+        "0011_fts_porter_stemming.sql",
     ]
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "nampara-librarian"
-version = "1.6.1"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -1141,7 +1141,7 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.410" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.411" },
     { name = "pytesseract", marker = "extra == 'all'", specifier = ">=0.3.13" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3.13" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
@@ -1835,15 +1835,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.410"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes every actionable finding from the exhaustive codebase audit, plus a follow-up UI/UX and agent-drivability pass. 17 commits, grouped by concern:

- **Pipeline fidelity (Tier 1):** chunk seam duplication eliminated (chunks tile exactly; the cleaner gets read-only predecessor context instead of re-emitted overlap), LLM truncation now detected via `finish_reason` and raised instead of silently publishing clipped text, blank cleaning results are never cached or published as success, transparent PNGs no longer OCR as black pages, multi-frame TIFFs keep all pages, MarkItDown subprocess no longer deadlocks on >64 KiB results.
- **Correctness (Tier 2):** page-manifest path moved to a ContextVar (fixes cross-conversion race), extraction cache now applies on `import` and folds the file extension + tessdata path into its key, reprocessing after a chunking change no longer hits `IntegrityError`, migrations apply transactionally, document+raw-text ingest is atomic, series keys require a real series title, cleaning workers cancel siblings on first failure, terminal runs can't be flipped back to RUNNING, the queue worker survives transient claim errors, SSE streams reuse one container / drain tail events / escape newlines, orphaned RUNNING runs are reconciled to FAILED at startup, and the backend exits when its launching desktop app dies (`LIBRARIAN_PARENT_PID` watcher).
- **Performance (Tier 3):** six indexes for previously-scanning hot reads, single tesseract pass for text+confidence (was two spawns per page), batched IN-clause cache reads, vectorized deskew scoring, and cache pruning via `admin db-maintain --prune-cache-days N`.
- **Accuracy (Tier 4):** FTS rebuilt with Porter stemming, new default cleaning prompt `cmos_v3` with explicit verbatim-preservation rules (numbers/units/dates/identifiers/tables), DOCX extracted in true document order, EXIF orientation applied before OCR, image→PDF shim honors embedded DPI, classification samples head+middle+tail of long documents instead of the first 8000 chars only.
- **Security & observability:** secret redaction extended to URL credentials (incl. empty-username DSNs), bare bearer tokens, and GitHub/Slack/AWS/Google key formats; X-Forwarded-For now trusts the rightmost untrusted hop instead of the spoofable leftmost; `/config` exposes 23 previously-hidden settings and a new `admin config` CLI prints the redacted effective configuration; cross-field config validators added.
- **CLI agent surface:** `--json` added to `import` (full report to stdout), `convert-dir`, `admin runs`, `admin queue`, `admin run-cancel`, `admin run-retry` (returns the new run id), and `version`; fixed `convert-dir` silently not writing the provenance sidecars its own help said were always written.
- **Mac app UX:** persistent Add Files (toolbar + ⌘O), Stop that actually cancels backend runs (with the queued-item and createRun-window races fixed), a new Library window (⌘L) with stemmed search / save-a-copy / delete, failure Details popover fed by the run event log, 60 s boot budget for slow cold starts with a boot-generation token preventing zombie relaunches, figure-vision + cleaning-style settings, Reclaim Disk Space + effective-config panel in Diagnostics, and assorted accessibility/keyboard fixes. Two independent line-by-line reviews were run over the Swift changes; the `Mac App` workflow compiles both architectures green on this PR.
- **Supply-chain pins (filled after the first CI round):** the python-build-standalone pin pointed at a release (20260602) that never shipped CPython 3.12.13 — re-pinned to 20260623 with real per-arch SHA256 digests, cross-verified against two independent sources (GitHub's per-asset digests on the release page and the table vendored in uv 0.11.26, exact match). The Homebrew installer is pinned to commit `184a7bce` (script fetched and reviewed). The macOS test fixtures also gained portable font resolution — Pillow's tiny bitmap fallback on macOS made tesseract's orientation detection fail, which was masking nothing on Linux where DejaVu exists.

## Verification

- [x] `ruff check .`
- [x] `pyright`
- [x] `pytest` (595 passed, 3 skipped)
- [x] `python -m build`
- [x] Docker build if deployment/runtime dependencies changed — Dockerfile changed (layer-caching + optional constraints pinning only, no dependency changes); the CI `test` job's Docker build step passes on this PR

## Data Safety

- [x] No private documents, transcripts, secrets, provider logs, or sensitive eval outputs added.
- [x] New fixtures are synthetic, public-domain, or explicitly approved for open-source use.

## Notes

- Migration `0011` rebuilds both FTS tables with the Porter tokenizer; repopulation comes from source-of-truth rows, so no content is lost, but the first startup after upgrade re-indexes existing text.
- The default cleaning prompt moved `cmos_v2` → `cmos_v3`; `cmos_v2` remains available and previously cached cleanings stay valid under their recorded prompt version.
- Verified fixes empirically where possible: seam dedup (39 dups → 0 on repro), stemmed search matches, migration rollback atomicity, cache prune retention, batched cache reads across the 400-item batch boundary, parent-death watcher against a reaped PID, and an end-to-end CLI JSON round trip (import → runs → queue → convert-dir).