### PR TITLE
Release 1.8.1: packaging re-release of 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.8.1 - 2026-07-09
+
+Packaging re-release of 1.8.0 — **no code changes**. The 1.8.0 code and Docker image published
+correctly, but its GitHub release was created outside the release workflow, so the workflow could
+not attach the build artifacts (the Python wheel/sdist and both macOS DMGs) to the immutable
+release. 1.8.1 re-runs the release cleanly so those downloads are available.
+
+If you already run 1.8.0 (via `pip`, the Docker image, or source), there is nothing new to pick up
+here. Mac users who could not download a 1.8.0 DMG should install the 1.8.1 DMG. See the 1.8.0
+notes below for what actually changed — most visibly, plain-text documents now get real Markdown
+headings for their titles and chapter/section lines (`cmos_v4`).
+
 ## 1.8.0 - 2026-07-08
 
 Quality release: the full codebase-audit fix wave (#50) plus plain-text heading inference.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ own machine.
 > exportable library. The extractor is best-in-class; the **clean-up and organization are what make
 > it Librarian**.
 
-Version `1.8.0` is the stable production release. Everything runs locally by default — source files
+Version `1.8.1` is the stable production release. Everything runs locally by default — source files
 and generated outputs live in a SQLite-backed workspace on your disk, and text leaves your machine
 only when *you* point cleaning, classification, or OCR-correction at an external model provider.
 
@@ -61,7 +61,7 @@ pip install "nampara-librarian[all]"      # [all] pulls every optional capabilit
 librarian doctor                          # confirm what's available
 ```
 
-> From a release wheel: `pip install "nampara_librarian-1.8.0-py3-none-any.whl[all]"` ·
+> From a release wheel: `pip install "nampara_librarian-1.8.1-py3-none-any.whl[all]"` ·
 > From a checkout: `pip install -e ".[dev,all]"`
 
 ---

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ import root:
 docker run --rm -p 8080:8080 \
   -e LIBRARIAN_API_KEY=change-me \
   -e LIBRARIAN_API_IMPORT_ROOT=/data/imports \
-  ghcr.io/nampara-ai/librarian:v1.8.0
+  ghcr.io/nampara-ai/librarian:v1.8.1
 ```
 
 ## Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nampara-librarian"
-version = "1.8.0"
+version = "1.8.1"
 description = "Local-first corpus cleaner and library organizer with CLI and API surfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/librarian/version.py
+++ b/src/librarian/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -74,7 +74,7 @@ def test_release_docs_describe_stable_surface() -> None:
     operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Version `1.8.0` is the stable production release." in readme
+    assert "Version `1.8.1` is the stable production release." in readme
     assert "librarian admin page-manifest" in operations
     assert "librarian maintainer eval" in operations
     assert "## 1.0.0 - 2026-05-22" in changelog


### PR DESCRIPTION
## Summary

**No code changes** — this re-cuts the 1.8.0 release so its downloadable artifacts actually get published.

1.8.0's code and Docker image (`ghcr.io/nampara-ai/librarian:v1.8.0` + `:latest`) shipped fine, but its GitHub release was created manually in the UI rather than by the tag-triggered release workflow. The workflow builds every artifact (wheel, sdist, SBOM, checksums, **both macOS DMGs**) and creates the release with all of them attached as its final step — but that step aborts if a release for the tag already exists, because GitHub releases are immutable and can't be completed after the fact. So the release ended up empty: no wheel, no DMGs.

1.8.1 fixes this by cutting the release the intended way — **push the `v1.8.1` tag only** and let the workflow own release creation. Bumps version to 1.8.1 (pyproject.toml + version.py; the Mac app stamps Info.plist from version.py at build time), adds a 1.8.1 CHANGELOG entry that explains the re-release and points back to 1.8.0 for the actual changes, and updates the README stable-version line + wheel example, the DEPLOYMENT image tag, and the release-doc test.

**After merge:** push `v1.8.1` (tag only — do **not** create the release in the UI). The Release workflow then builds and publishes a complete GitHub release with the DMGs + wheel, and the Mac App workflow builds both DMGs.

## Verification

- [x] `ruff check .`
- [x] `pyright`
- [x] `pytest` (596 passed, 3 skipped; release-doc + metadata-consistency tests updated for 1.8.1)
- [x] `python -m build` (1.8.1 sdist + wheel)
- [x] `check_changelog_ready.py --version v1.8.1` passes and `release_notes.py` extracts the 1.8.1 section cleanly
- [x] Docker build if deployment/runtime dependencies changed — no dependency or Dockerfile changes

## Data Safety

- [x] No private documents, transcripts, secrets, provider logs, or sensitive eval outputs added.
- [x] New fixtures are synthetic, public-domain, or explicitly approved for open-source use.

## Notes

- The empty v1.8.0 GitHub release can be left as-is (its notes point at the changelog) or deleted if your ruleset permits; either way 1.8.1 is the one carrying the DMG/wheel downloads. The 1.8.0 git tag, code, and Docker image remain valid.
- Root cause is process, not code: for this repo, cut releases by pushing the version tag and letting the workflow create the release — never "Draft a new release" in the UI, which pre-creates the immutable release object and pre-empts the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_