### PR TITLE
Security: bump soupsieve 2.8.3 → 2.8.4 (CVE-2026-49476, CVE-2026-49477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,22 @@
 
 ## 1.8.1 - 2026-07-09
 
-Packaging re-release of 1.8.0 — **no code changes**. The 1.8.0 code and Docker image published
-correctly, but its GitHub release was created outside the release workflow, so the workflow could
-not attach the build artifacts (the Python wheel/sdist and both macOS DMGs) to the immutable
-release. 1.8.1 re-runs the release cleanly so those downloads are available.
+Re-release of 1.8.0 with a dependency security patch — **no application code changes**.
 
-If you already run 1.8.0 (via `pip`, the Docker image, or source), there is nothing new to pick up
-here. Mac users who could not download a 1.8.0 DMG should install the 1.8.1 DMG. See the 1.8.0
-notes below for what actually changed — most visibly, plain-text documents now get real Markdown
-headings for their titles and chapter/section lines (`cmos_v4`).
+- Security: bump `soupsieve` 2.8.3 → 2.8.4 (a transitive dependency via BeautifulSoup, which
+  MarkItDown uses) to resolve two high-severity advisories, CVE-2026-49476 and CVE-2026-49477.
+  Librarian only exercises soupsieve when parsing HTML through the optional MarkItDown extractor;
+  the bump ships in the pinned runtime bundled with the macOS app and Docker image.
+- Packaging: 1.8.0's code and Docker image published correctly, but its GitHub release was created
+  outside the release workflow, so the workflow could not attach the build artifacts (the Python
+  wheel/sdist and both macOS DMGs) to the immutable release. 1.8.1 re-runs the release cleanly so
+  those downloads are available.
+
+If you already run 1.8.0 (via `pip`, the Docker image, or source), the only change to pick up here
+is the soupsieve security patch. Mac users who could not download a 1.8.0 DMG should install the
+1.8.1 DMG. See the 1.8.0 notes below for what actually changed in the feature set — most visibly,
+plain-text documents now get real Markdown headings for their titles and chapter/section lines
+(`cmos_v4`).
 
 ## 1.8.0 - 2026-07-08
 

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "nampara-librarian"
-version = "1.7.1"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -2211,11 +2211,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves the Dependabot High-severity alert on `soupsieve`. `pip-audit` reports two advisories in `soupsieve 2.8.3` — **CVE-2026-49476** and **CVE-2026-49477** — both fixed in **2.8.4**.

`soupsieve` is a transitive dependency: `soupsieve` ← `beautifulsoup4` ← `markitdown` / `markdownify`. Librarian only exercises it when parsing HTML through the optional MarkItDown extractor. `uv lock --upgrade-package soupsieve` moves **only** soupsieve (2.8.3 → 2.8.4) and refreshes the lock's own self-version to 1.8.1 — no other package versions change.

Because the pinned lock drives `constraints.txt`, which pins the Python runtime bundled in the macOS app and the Docker image, folding this into the still-untagged **1.8.1** release ships the patch on every platform in one go. Documented under the existing 1.8.1 CHANGELOG entry.

## Verification

- [x] `uv lock --upgrade-package soupsieve` — diff is soupsieve 2.8.3 → 2.8.4 and the self-version 1.7.1 → 1.8.1, nothing else
- [x] `pip-audit` — **No known vulnerabilities found** after the bump (was 2 before)
- [x] `ruff check .`
- [x] `pyright`
- [x] `pytest` (596 passed, 3 skipped)
- [x] `check_changelog_ready.py --version v1.8.1` passes

## Data Safety

- [x] No private documents, transcripts, secrets, provider logs, or sensitive eval outputs added.
- [x] No new fixtures.

## Notes

- Sequencing: this should merge **before** the `v1.8.1` tag is pushed, so the tag includes the patch. After merge, tag `v1.8.1` at the new `main` HEAD (tag only — the workflow creates the release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_