### PR TITLE
Fix macOS "Engine didn't start": ad-hoc build forced hardened runtime without the entitlement

### DIFF
--- a/.github/workflows/macapp.yml
+++ b/.github/workflows/macapp.yml
@@ -221,6 +221,21 @@ jobs:
         working-directory: apps/macos
         run: scripts/sign_app.sh --app dist/Librarian.app
 
+      - name: Verify the SIGNED app starts
+        working-directory: apps/macos
+        run: |
+          # Run the signed interpreter through the app's real startup import
+          # chain (librarian -> pydantic -> pydantic_core native extension).
+          # Signing is what applies the hardened runtime and entitlements, so a
+          # code-signing mistake that blocks loading third-party native
+          # extensions (e.g. hardened runtime WITHOUT
+          # com.apple.security.cs.disable-library-validation) only surfaces
+          # here. The pre-sign OCR/connectivity checks run against the unsigned
+          # bundle and cannot catch it. Runs for both ad-hoc and Developer ID
+          # builds so neither can ship an engine that won't boot.
+          PY="dist/Librarian.app/Contents/Resources/backend/python/bin/python3"
+          "$PY" -m librarian version
+
       - name: Create DMG
         working-directory: apps/macos
         run: scripts/make_dmg.sh --app dist/Librarian.app --output "dist/${{ matrix.artifact }}.dmg"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.8.2 - 2026-07-20
+
+macOS app fix — **no engine or Python changes**.
+
+- Fix "Engine didn't start" on the 1.8.0/1.8.1 macOS app. The 1.8.0 signing change enabled the
+  hardened runtime for ad-hoc (unsigned) builds — which is what CI ships when no Developer ID
+  certificate is configured — but only attached the `disable-library-validation` entitlement to
+  Developer ID builds. The hardened runtime then enforced library validation with nothing to
+  satisfy it, so the bundled Python could not load its third-party native extensions (pydantic-core,
+  Pillow, PDFium, …) and the backend crashed on startup. Ad-hoc builds no longer enable the
+  hardened runtime (restoring the 1.7.1 behavior), so the embedded interpreter loads its extensions
+  normally; Developer ID builds keep the hardened runtime plus the entitlement for notarization.
+- Add a post-signing smoke test to the macOS build: it runs the signed interpreter through the
+  app's real startup import chain (`librarian` → `pydantic` → `pydantic_core`), so a signing
+  regression that blocks native extensions fails CI instead of shipping. The previous OCR and
+  connectivity checks ran only against the unsigned bundle and could not catch this.
+
 ## 1.8.1 - 2026-07-09
 
 Re-release of 1.8.0 with a dependency security patch — **no application code changes**.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ own machine.
 > exportable library. The extractor is best-in-class; the **clean-up and organization are what make
 > it Librarian**.
 
-Version `1.8.1` is the stable production release. Everything runs locally by default — source files
+Version `1.8.2` is the stable production release. Everything runs locally by default — source files
 and generated outputs live in a SQLite-backed workspace on your disk, and text leaves your machine
 only when *you* point cleaning, classification, or OCR-correction at an external model provider.
 
@@ -61,7 +61,7 @@ pip install "nampara-librarian[all]"      # [all] pulls every optional capabilit
 librarian doctor                          # confirm what's available
 ```
 
-> From a release wheel: `pip install "nampara_librarian-1.8.1-py3-none-any.whl[all]"` ·
+> From a release wheel: `pip install "nampara_librarian-1.8.2-py3-none-any.whl[all]"` ·
 > From a checkout: `pip install -e ".[dev,all]"`
 
 ---

--- a/apps/macos/scripts/sign_app.sh
+++ b/apps/macos/scripts/sign_app.sh
@@ -32,20 +32,34 @@ done
 #     executable memory. Applying them to every nested binary — including the
 #     bundled OCR tools (tesseract/pdftoppm/...) — needlessly widens the attack
 #     surface.
-#   - Every Mach-O still gets the hardened runtime (--options runtime) for
-#     notarization; the OCR tools are signed WITHOUT the broad entitlements.
+#   - For a Developer ID identity every Mach-O gets the hardened runtime
+#     (--options runtime) for notarization; the OCR tools are signed WITHOUT
+#     the broad entitlements. Ad-hoc builds get no hardened runtime (see below).
 #
-# Always apply --options runtime so the hardened runtime is consistent across
-# ad-hoc and Developer ID signing. Entitlements/timestamp only apply for a real
-# Developer ID identity (ad-hoc "-" signing cannot carry them meaningfully).
+# Hardened runtime turns on library validation, which refuses to load any
+# native library not signed by the process's own Team ID. The embedded CPython
+# loads dozens of third-party C-extension .so files (pydantic_core, Pillow,
+# numpy, PDFium, ...) that carry their upstream signatures, so a hardened
+# process MUST also carry com.apple.security.cs.disable-library-validation or
+# it cannot import them and the backend dies on startup ("Engine didn't start").
+#
+# For a real Developer ID identity we apply BOTH (hardened runtime for
+# notarization + the entitlement so libraries still load). For an ad-hoc build
+# ("-", what CI ships when no signing cert is configured) we deliberately do
+# NOT enable the hardened runtime: without it, library validation is not
+# enforced and the third-party extensions load normally. Enabling hardened
+# runtime on an ad-hoc build without the entitlement is exactly the regression
+# that broke the engine — do not "consistency-fix" this back.
 
-# Base flags for every binary: hardened runtime, no broad entitlements.
-BASE_FLAGS=(--force --sign "$IDENTITY" --options runtime)
-# Flags for the Python interpreter: base + the broad entitlements.
-PY_FLAGS=(--force --sign "$IDENTITY" --options runtime)
+# Base flags for every binary. Hardened runtime + entitlements are added below
+# only for a real Developer ID identity.
+BASE_FLAGS=(--force --sign "$IDENTITY")
+# Flags for the Python interpreter and the app bundle (the processes that load
+# the extensions): base + the broad entitlements when hardened.
+PY_FLAGS=(--force --sign "$IDENTITY")
 if [[ "$IDENTITY" != "-" ]]; then
-  BASE_FLAGS+=(--timestamp)
-  PY_FLAGS+=(--timestamp --entitlements "$ENTITLEMENTS")
+  BASE_FLAGS+=(--options runtime --timestamp)
+  PY_FLAGS+=(--options runtime --timestamp --entitlements "$ENTITLEMENTS")
 fi
 
 # The interpreter binaries that legitimately need the broad entitlements. These

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ import root:
 docker run --rm -p 8080:8080 \
   -e LIBRARIAN_API_KEY=change-me \
   -e LIBRARIAN_API_IMPORT_ROOT=/data/imports \
-  ghcr.io/nampara-ai/librarian:v1.8.1
+  ghcr.io/nampara-ai/librarian:v1.8.2
 ```
 
 ## Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nampara-librarian"
-version = "1.8.1"
+version = "1.8.2"
 description = "Local-first corpus cleaner and library organizer with CLI and API surfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/librarian/version.py
+++ b/src/librarian/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -74,7 +74,7 @@ def test_release_docs_describe_stable_surface() -> None:
     operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Version `1.8.1` is the stable production release." in readme
+    assert "Version `1.8.2` is the stable production release." in readme
     assert "librarian admin page-manifest" in operations
     assert "librarian maintainer eval" in operations
     assert "## 1.0.0 - 2026-05-22" in changelog

--- a/uv.lock
+++ b/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "nampara-librarian"
-version = "1.8.1"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Fixes the **"Engine didn't start"** failure on the 1.8.0/1.8.1 macOS app. Diagnosed from a user's `backend.log`:

```
ImportError: dlopen(.../pydantic_core/_pydantic_core.cpython-312-darwin.so):
code signature ... not valid for use in process:
mapping process and mapped file (non-platform) have different Team IDs
```

**Root cause (a regression from #50):** the 1.8.0 signing rework in `sign_app.sh` began applying the **hardened runtime (`--options runtime`) to every build, including ad-hoc** — which is what CI ships when no Developer ID cert secret is configured — but kept the `com.apple.security.cs.disable-library-validation` entitlement gated behind having a real Developer ID identity. The hardened runtime then enforced **library validation** with nothing to satisfy it, so the bundled CPython could not `dlopen` its third-party native extensions (pydantic-core, Pillow, PDFium, numpy…), and the backend crashed on startup. 1.7.1 worked because its ad-hoc path used a plain signature with **no** hardened runtime.

## Fix

- **`apps/macos/scripts/sign_app.sh`** — only enable `--options runtime` (and the entitlements/timestamp) for a real Developer ID identity. Ad-hoc builds get a plain signature with no hardened runtime, restoring the working 1.7.1 behavior, so library validation isn't enforced and the extensions load. Developer ID builds are unchanged: hardened runtime + `disable-library-validation` + timestamp for notarization. Added a prominent comment so this isn't "consistency-fixed" back.
- **`.github/workflows/macapp.yml`** — new **post-signing** smoke test that runs the *signed* interpreter through the app's real startup import chain (`librarian` → `pydantic` → `pydantic_core`). The existing OCR/connectivity checks run against the *unsigned* bundle and structurally cannot catch a signing regression. This new step runs for both ad-hoc and Developer ID builds, so **this PR's own macOS CI validates the fix on real hardware**.

No engine or Python code changes. Version bump to 1.8.2 + CHANGELOG.

## Verification

- [x] `ruff check .`, `pyright`
- [x] `check_changelog_ready.py` / `release_notes.py` for v1.8.2 pass
- [x] `bash -n sign_app.sh`, macapp.yml YAML parses
- [x] **The new post-sign smoke test in this PR's `dmg` CI jobs is the real proof** — if the ad-hoc-signed app can now import pydantic_core, the fix is confirmed on macOS
- [ ] Local `pytest`: 6 OCR/liteparse tests fail **in the CI sandbox only** because this reclaimed container has no `tesseract` binary (apt is proxy-blocked) — unrelated to this diff, which touches no extraction code. The repo's `test` job installs tesseract and runs them green.

## Notes

- After merge, push the `v1.8.2` tag (tag only — not via the UI) to ship the corrected DMGs.
- Immediate workaround for anyone stuck on 1.8.0/1.8.1 without waiting for 1.8.2: re-sign the installed app ad-hoc without the hardened runtime — `codesign --force --deep --sign - /Applications/Librarian.app` — then relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_