### PR TITLE
Release 1.8.3: ship pillow + cryptography security bumps in the bundle

### DIFF
--- a/.github/workflows/macapp.yml
+++ b/.github/workflows/macapp.yml
@@ -31,16 +31,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both DMGs build on plentiful Apple Silicon runners. The arm64
-          # binaries come from the native Homebrew; the x86_64 binaries come
-          # from an x86_64 Homebrew installed under Rosetta, so releases never
-          # wait on (increasingly scarce) native Intel runners.
+          # Apple Silicon only. We used to also cross-build an Intel (x86_64)
+          # DMG under Rosetta, but cryptography (pulled in by markitdown[pdf]
+          # via pdfminer-six) dropped Intel macOS wheels at 49.0.0 — the same
+          # release that fixed the CVEs the bundle must ship. A self-contained
+          # Intel app therefore can't be built from prebuilt wheels without
+          # shipping a vulnerable cryptography, so we no longer publish it.
+          # Intel Mac users install via pip or Docker, which stay patched.
           - arch: arm64
             artifact: Librarian-AppleSilicon
             brew_prefix: /opt/homebrew
-          - arch: x86_64
-            artifact: Librarian-Intel
-            brew_prefix: /usr/local
     steps:
       - uses: actions/checkout@v7
         with:
@@ -61,10 +61,6 @@ jobs:
         # pinned/reproducible rather than resolved to latest at build time.
         run: python .github/scripts/export_constraints.py --output constraints.txt
 
-      - name: Ensure Rosetta 2 (x86_64 build on Apple Silicon)
-        if: matrix.arch == 'x86_64'
-        run: sudo softwareupdate --install-rosetta --agree-to-license
-
       - name: Build app bundle
         working-directory: apps/macos
         run: make app ARCH_FLAGS="--arch ${{ matrix.arch }}"
@@ -79,28 +75,7 @@ jobs:
             --constraints ../../constraints.txt
 
       - name: Install OCR tools (arm64 native Homebrew)
-        if: matrix.arch == 'arm64'
         run: brew install tesseract poppler dylibbundler
-
-      - name: Install OCR tools (x86_64 Homebrew under Rosetta)
-        if: matrix.arch == 'x86_64'
-        run: |
-          # Bootstrap an x86_64 Homebrew at /usr/local (the installer picks the
-          # prefix from the running architecture, so run it under Rosetta), then
-          # install the Intel OCR binaries there.
-          # Pin the Homebrew installer to an immutable commit SHA instead of the
-          # moving HEAD ref, so a compromised or changed upstream install.sh
-          # cannot be pulled into the build. Pinned to Homebrew/install commit
-          # 184a7bce ("Fix DNF group advice", 2026-06-21); the script at this
-          # SHA was fetched and reviewed before pinning. To bump:
-          #   gh api 'repos/Homebrew/install/commits?path=install.sh&per_page=1' --jq '.[0].sha'
-          # then re-review the fetched script before updating the value.
-          HOMEBREW_INSTALL_SHA="184a7bce1569b711ecb5451f5e9a3d30cb444242"
-          if [ ! -x /usr/local/bin/brew ]; then
-            NONINTERACTIVE=1 arch -x86_64 /bin/bash -c \
-              "$(curl -fsSL "https://raw.githubusercontent.com/Homebrew/install/${HOMEBREW_INSTALL_SHA}/install.sh")" </dev/null
-          fi
-          arch -x86_64 /usr/local/bin/brew install tesseract poppler dylibbundler
 
       - name: Bundle OCR tools
         working-directory: apps/macos
@@ -166,9 +141,8 @@ jobs:
       - name: Verify bundled runtime can reach AI providers
         working-directory: apps/macos
         run: |
-          # The x86_64 interpreter runs under Rosetta here, same as during
-          # bundling. A 401 proves DNS, TCP, and TLS all work from the
-          # bundled runtime; certificate failures or timeouts fail the build.
+          # A 401 proves DNS, TCP, and TLS all work from the bundled runtime;
+          # certificate failures or timeouts fail the build.
           PY="dist/Librarian.app/Contents/Resources/backend/python/bin/python3"
           "$PY" <<'CHECK'
           import urllib.error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,6 @@ jobs:
             sleep 30
           done
           test -f dmgs/Librarian-AppleSilicon/Librarian-AppleSilicon.dmg
-          test -f dmgs/Librarian-Intel/Librarian-Intel.dmg
       - name: Verify DMG app version matches tag
         run: |
           # Mirror the tag-vs-package check for the built macOS app: mount each
@@ -142,8 +141,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends p7zip-full
           EXPECTED="${GITHUB_REF_NAME#v}"
-          for dmg in dmgs/Librarian-AppleSilicon/Librarian-AppleSilicon.dmg \
-                     dmgs/Librarian-Intel/Librarian-Intel.dmg; do
+          for dmg in dmgs/Librarian-AppleSilicon/Librarian-AppleSilicon.dmg; do
             workdir="$(mktemp -d)"
             # Extract the app's Info.plist out of the DMG (UDZO -> HFS payload).
             7z x -y -o"$workdir" "$dmg" >/dev/null
@@ -261,7 +259,6 @@ jobs:
           gh release create "${{ github.ref_name }}" \
             dist/* sbom.json constraints.txt SHA256SUMS.txt \
             dmgs/Librarian-AppleSilicon/Librarian-AppleSilicon.dmg \
-            dmgs/Librarian-Intel/Librarian-Intel.dmg \
             --repo "${{ github.repository }}" \
             --title "${{ github.ref_name }}" \
             --notes-file release-notes.md \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.8.3 - 2026-08-23
+
+Dependency security patch — **no engine or Python code changes**.
+
+- Ship the pinned dependency security updates that missed the 1.8.2 cut. 1.8.2 was tagged before
+  these bumps merged, so its bundled runtime (macOS app + Docker image) still pinned the vulnerable
+  versions. 1.8.3 releases from current `main`, so the fixes are in the bundle:
+  - **pillow 12.2.0 → 12.3.0** — resolves 12 advisories (PYSEC-2026-2253/2254/2255/2256,
+    3451–3454, 3493–3496).
+  - **cryptography 48.0.1 → 50.0.0** — resolves 3 advisories (PYSEC-2026-3552/3553/3554).
+- `pip install`/source users on 1.8.2 already resolved the fixed versions via the `>=` ranges; this
+  release matters most for the pinned macOS app and Docker bundles.
+
 ## 1.8.2 - 2026-07-20
 
 macOS app fix — **no engine or Python changes**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Dependency security patch plus a figure-vision fix.
   - **cryptography 48.0.1 → 50.0.0** — resolves 3 advisories (PYSEC-2026-3552/3553/3554).
 - `pip install`/source users on 1.8.2 already resolved the fixed versions via the `>=` ranges; this
   release matters most for the pinned macOS app and Docker bundles.
+- **The native macOS app is now Apple Silicon only; the Intel (x86_64) DMG is discontinued.**
+  cryptography (pulled in by `markitdown[pdf]` via pdfminer-six) dropped Intel macOS wheels at
+  49.0.0 — the same release that fixed the advisories above — so a self-contained, security-patched
+  Intel app can no longer be built from prebuilt wheels. Intel Mac users should install with
+  `pip install "nampara-librarian[all]"` or run the Docker image; both stay patched.
 
 ## 1.8.2 - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## 1.8.3 - 2026-08-23
 
-Dependency security patch — **no engine or Python code changes**.
+Dependency security patch plus a figure-vision fix.
 
+- Fix figure-vision enrichment silently doing nothing with liteparse 2.2.x. liteparse emits image
+  placeholders as `![](img_p1_1.png)` at runtime, but Librarian only looked for the older
+  `![](image_...)` form (liteparse's own type docstring still shows the old form), so no placeholder
+  ever matched and no figure was described even with `LIBRARIAN_FIGURE_VISION_ENABLED=true`.
+  Enrichment now matches either form, so a future placeholder-format shift can't disable it again.
 - Ship the pinned dependency security updates that missed the 1.8.2 cut. 1.8.2 was tagged before
   these bumps merged, so its bundled runtime (macOS app + Docker image) still pinned the vulnerable
   versions. 1.8.3 releases from current `main`, so the fixes are in the bundle:

--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ All three run the **same engine** and the **same local SQLite library**.
 ### The Mac app (no terminal, nothing to set up)
 
 1. Download [**Librarian-AppleSilicon.dmg**](https://github.com/nampara-ai/librarian/releases/latest/download/Librarian-AppleSilicon.dmg)
-   (M-series) or [**Librarian-Intel.dmg**](https://github.com/nampara-ai/librarian/releases/latest/download/Librarian-Intel.dmg)
-   (Intel). If a direct link doesn't resolve, grab the DMG from the [latest release](https://github.com/nampara-ai/librarian/releases/latest) assets.
+   (Apple Silicon — M-series). If a direct link doesn't resolve, grab the DMG from the [latest release](https://github.com/nampara-ai/librarian/releases/latest) assets.
 2. Open the DMG and drag **Librarian** to **Applications**. First launch: right-click → **Open** once to clear Gatekeeper.
 3. Drop files anywhere in the window.
+
+> **Intel Macs:** the native app is Apple Silicon only — a security-patched
+> self-contained Intel build is no longer possible (a bundled dependency
+> dropped Intel macOS wheels). Install via `pip` or Docker below instead.
 
 The app bundles the high-fidelity extraction engine **and** its OCR — scanned PDFs are read fully
 offline, no Homebrew, no `PATH` setup, no first-run downloads. See [apps/macos](apps/macos/README.md)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ own machine.
 > exportable library. The extractor is best-in-class; the **clean-up and organization are what make
 > it Librarian**.
 
-Version `1.8.2` is the stable production release. Everything runs locally by default — source files
+Version `1.8.3` is the stable production release. Everything runs locally by default — source files
 and generated outputs live in a SQLite-backed workspace on your disk, and text leaves your machine
 only when *you* point cleaning, classification, or OCR-correction at an external model provider.
 
@@ -61,7 +61,7 @@ pip install "nampara-librarian[all]"      # [all] pulls every optional capabilit
 librarian doctor                          # confirm what's available
 ```
 
-> From a release wheel: `pip install "nampara_librarian-1.8.2-py3-none-any.whl[all]"` ·
+> From a release wheel: `pip install "nampara_librarian-1.8.3-py3-none-any.whl[all]"` ·
 > From a checkout: `pip install -e ".[dev,all]"`
 
 ---

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -36,13 +36,19 @@ to Applications, double-click, done.
 
 ## Install (for users)
 
-1. Download the DMG for your Mac from the assets of the
-   [latest release](https://github.com/nampara-ai/librarian/releases/latest):
-   - **Librarian-AppleSilicon.dmg** for M1/M2/M3/M4 Macs
-   - **Librarian-Intel.dmg** for Intel Macs
+1. Download **Librarian-AppleSilicon.dmg** (Apple Silicon — M1/M2/M3/M4 Macs)
+   from the assets of the
+   [latest release](https://github.com/nampara-ai/librarian/releases/latest).
 
    (Apple menu → About This Mac shows which chip you have. DMGs are attached
    to releases from v1.1.0 onward.)
+
+   **Intel Macs:** the native app is Apple Silicon only as of v1.8.3. A bundled
+   dependency (cryptography, via `markitdown[pdf]`) dropped Intel macOS wheels
+   at the same release that fixed its security advisories, so a self-contained
+   Intel app can no longer be built without shipping a vulnerable version.
+   Intel users should install via `pip install "nampara-librarian[all]"` or run
+   the Docker image — both stay patched.
 2. Open the DMG and drag **Librarian** into **Applications**.
 3. Launch Librarian and drop a file anywhere in the window.
 
@@ -166,14 +172,17 @@ make dmg                # dist/Librarian.dmg
 `make bundled-app` accepts `WHEEL=...` (wheel path or PyPI requirement),
 `BUNDLE_ARCH=arm64|x86_64`, and `IDENTITY="Developer ID Application: ..."` for
 real signing. The bundled Python version is pinned in
-`scripts/bundle_backend.sh`.
+`scripts/bundle_backend.sh`. (`BUNDLE_ARCH=x86_64` still works for local Intel
+builds, but note that some pinned dependencies no longer publish Intel macOS
+wheels, so such a build may not resolve against the release constraints.)
 
 ## Release pipeline (CI)
 
-`.github/workflows/macapp.yml` builds both DMGs on a macOS runner for every
-`v*` tag (and on demand via workflow dispatch) and attaches them to the GitHub
-release as `Librarian-AppleSilicon.dmg` and `Librarian-Intel.dmg` — which is
-what the stable `releases/latest/download/...` links point at.
+`.github/workflows/macapp.yml` builds the Apple Silicon DMG on a macOS runner
+for every `v*` tag (and on demand via workflow dispatch) and attaches it to the
+GitHub release as `Librarian-AppleSilicon.dmg` — which is what the stable
+`releases/latest/download/...` link points at. (The Intel DMG was dropped in
+v1.8.3; see the Install section above.)
 
 Builds are ad-hoc signed by default. To ship notarized builds that open with
 zero Gatekeeper friction, add these repository secrets (requires an Apple

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,7 +48,7 @@ import root:
 docker run --rm -p 8080:8080 \
   -e LIBRARIAN_API_KEY=change-me \
   -e LIBRARIAN_API_IMPORT_ROOT=/data/imports \
-  ghcr.io/nampara-ai/librarian:v1.8.2
+  ghcr.io/nampara-ai/librarian:v1.8.3
 ```
 
 ## Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nampara-librarian"
-version = "1.8.2"
+version = "1.8.3"
 description = "Local-first corpus cleaner and library organizer with CLI and API surfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/librarian/ingest/extractors.py
+++ b/src/librarian/ingest/extractors.py
@@ -828,9 +828,27 @@ class FigureImage:
     data: bytes
 
     @property
-    def placeholder(self) -> str:
-        """The markdown placeholder liteparse emits for this image."""
-        return f"![](image_{self.id}.png)"
+    def placeholder_candidates(self) -> tuple[str, ...]:
+        """Markdown image references liteparse may emit for this image.
+
+        liteparse 2.2.x emits ``![](img_{id}.png)`` at runtime, while its own
+        type docstring still shows the older ``![](image_{id}.png)`` form.
+        Match either so a liteparse placeholder-format shift can't silently
+        disable figure enrichment again (it already regressed once, matching
+        only ``image_`` while the engine emitted ``img_``).
+        """
+        return (f"![](img_{self.id}.png)", f"![](image_{self.id}.png)")
+
+    def find_placeholder(self, markdown: str) -> str | None:
+        """Return this image's placeholder exactly as it appears in ``markdown``.
+
+        Returns ``None`` when no known placeholder form is present, so the
+        caller skips an image liteparse did not actually reference.
+        """
+        for candidate in self.placeholder_candidates:
+            if candidate in markdown:
+                return candidate
+        return None
 
 
 _FIGURE_MEDIA_TYPES = {
@@ -876,14 +894,15 @@ async def enrich_markdown_figures(
     # placeholder, keep the first so the replace(count=1) loop can't append the
     # second figure's description into the first figure's (now re-introduced)
     # placeholder text.
-    eligible: list[FigureImage] = []
+    eligible: list[tuple[FigureImage, str]] = []
     seen_placeholders: set[str] = set()
     for figure in figures:
-        if figure.placeholder in seen_placeholders:
+        placeholder = figure.find_placeholder(markdown)
+        if placeholder is None or placeholder in seen_placeholders:
             continue
-        if figure.placeholder in markdown and min_bytes <= len(figure.data) <= max_bytes:
-            eligible.append(figure)
-            seen_placeholders.add(figure.placeholder)
+        if min_bytes <= len(figure.data) <= max_bytes:
+            eligible.append((figure, placeholder))
+            seen_placeholders.add(placeholder)
         if len(eligible) >= max_figures:
             break
     if not eligible:
@@ -898,7 +917,9 @@ async def enrich_markdown_figures(
     vision_max_tokens = min(_MAX_FIGURE_VISION_TOKENS, max(256, math.ceil(max_response_chars / 3)))
     semaphore = asyncio.Semaphore(max(1, max_concurrency))
 
-    async def describe(figure: FigureImage) -> tuple[FigureImage, str | None]:
+    async def describe(
+        figure: FigureImage, placeholder: str
+    ) -> tuple[FigureImage, str, str | None]:
         async with semaphore:
             try:
                 description = await provider.describe_image(
@@ -911,18 +932,20 @@ async def enrich_markdown_figures(
                     temperature=temperature,
                 )
             except Exception:  # noqa: BLE001 - one figure must not fail the document
-                return figure, None
-        return figure, description.strip()[:max_response_chars] or None
+                return figure, placeholder, None
+        return figure, placeholder, description.strip()[:max_response_chars] or None
 
-    described = await asyncio.gather(*(describe(figure) for figure in eligible))
+    described = await asyncio.gather(
+        *(describe(figure, placeholder) for figure, placeholder in eligible)
+    )
 
     enriched = markdown
     count = 0
-    for figure, description in described:
+    for figure, placeholder, description in described:
         if not description:
             continue
-        block = f"{figure.placeholder}\n\n**Figure (page {figure.page}):** {description}"
-        enriched = enriched.replace(figure.placeholder, block, 1)
+        block = f"{placeholder}\n\n**Figure (page {figure.page}):** {description}"
+        enriched = enriched.replace(placeholder, block, 1)
         count += 1
     return enriched, count
 

--- a/src/librarian/version.py
+++ b/src/librarian/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.8.2"
+__version__ = "1.8.3"

--- a/tests/test_figure_vision.py
+++ b/tests/test_figure_vision.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import re
 import zlib
 from pathlib import Path
 
@@ -150,8 +151,17 @@ def test_figure_media_type_mapping() -> None:
     assert figure_media_type("tiff") == "image/png"  # unknown -> default png
 
 
-def test_figure_image_placeholder_property() -> None:
-    assert _fig("p3_1", 3, 10).placeholder == "![](image_p3_1.png)"
+def test_figure_image_placeholder_matching() -> None:
+    fig = _fig("p3_1", 3, 10)
+    # Both liteparse forms are candidates (runtime img_, docstring image_).
+    assert fig.placeholder_candidates == (
+        "![](img_p3_1.png)",
+        "![](image_p3_1.png)",
+    )
+    # find_placeholder returns whichever form is actually present.
+    assert fig.find_placeholder("a ![](img_p3_1.png) b") == "![](img_p3_1.png)"
+    assert fig.find_placeholder("a ![](image_p3_1.png) b") == "![](image_p3_1.png)"
+    assert fig.find_placeholder("no image here") is None
 
 
 @pytest.mark.asyncio
@@ -250,7 +260,10 @@ def test_liteparse_extractor_without_vision_leaves_placeholder(tmp_path: Path) -
     markdown = asyncio.run(extractor.extract(source))
 
     assert "**Figure (page" not in markdown
-    assert "![](image_" in markdown  # placeholder retained, unenriched
+    # Placeholder retained, unenriched. Match liteparse's real runtime form
+    # (img_) or its docstring form (image_) so this doesn't re-break on a
+    # placeholder-format shift.
+    assert re.search(r"!\[\]\(img(?:age)?_p\d+_\d+\.png\)", markdown)
 
 
 @requires_liteparse

--- a/tests/test_openai_compatible.py
+++ b/tests/test_openai_compatible.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, cast
 
 import httpx
 import openai
@@ -10,21 +10,33 @@ from librarian.llm.openai_compatible import OpenAICompatibleProvider, is_retriab
 from librarian.observability import MetricsRecorder
 
 
+# openai's exception constructors are type-stubbed against httpx2, while the
+# tests build real httpx objects; the httpx/httpx2 split otherwise trips
+# pyright on every dependency bump (CI resolves latest). Typing these as Any
+# keeps pyright stable while runtime still uses genuine httpx objects.
+def _fake_request() -> Any:
+    return httpx.Request("POST", "https://api.example.test")
+
+
+def _fake_response(status_code: int, request: Any) -> Any:
+    return httpx.Response(status_code, request=request)
+
+
 def test_openai_retry_classification() -> None:
-    request = httpx.Request("POST", "https://api.example.test")
+    request = _fake_request()
     assert is_retriable_openai_error(openai.APITimeoutError(request))
     assert is_retriable_openai_error(openai.APIConnectionError(request=request))
     assert is_retriable_openai_error(
         openai.RateLimitError(
             "rate limited",
-            response=httpx.Response(429, request=request),
+            response=_fake_response(429, request),
             body=None,
         )
     )
     assert is_retriable_openai_error(
         openai.APIStatusError(
             "server failed",
-            response=httpx.Response(503, request=request),
+            response=_fake_response(503, request),
             body=None,
         )
     )
@@ -32,14 +44,14 @@ def test_openai_retry_classification() -> None:
     assert not is_retriable_openai_error(
         openai.BadRequestError(
             "bad request",
-            response=httpx.Response(400, request=request),
+            response=_fake_response(400, request),
             body=None,
         )
     )
     assert not is_retriable_openai_error(
         openai.AuthenticationError(
             "bad auth",
-            response=httpx.Response(401, request=request),
+            response=_fake_response(401, request),
             body=None,
         )
     )
@@ -59,7 +71,7 @@ def test_openai_provider_fast_fails_when_api_key_missing(monkeypatch: pytest.Mon
 
 @pytest.mark.asyncio
 async def test_openai_provider_retries_transient_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    request = httpx.Request("POST", "https://api.example.test")
+    request = _fake_request()
     calls = 0
 
     class FakeChoice:
@@ -80,7 +92,7 @@ async def test_openai_provider_retries_transient_errors(monkeypatch: pytest.Monk
             if calls == 1:
                 raise openai.RateLimitError(
                     "rate limited",
-                    response=httpx.Response(429, request=request),
+                    response=_fake_response(429, request),
                     body=None,
                 )
             return FakeCompletion()
@@ -123,14 +135,14 @@ async def test_openai_provider_retries_transient_errors(monkeypatch: pytest.Monk
 async def test_openai_provider_redacts_non_retriable_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    request = httpx.Request("POST", "https://api.example.test")
+    request = _fake_request()
 
     class FakeCompletions:
         async def create(self, **kwargs: object) -> object:
             del kwargs
             raise openai.AuthenticationError(
                 "bad auth api_key=abc123 sk-testSECRET123",
-                response=httpx.Response(401, request=request),
+                response=_fake_response(401, request),
                 body=None,
             )
 
@@ -174,14 +186,14 @@ async def test_openai_provider_redacts_non_retriable_errors(
 async def test_openai_provider_redacts_retry_exhaustion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    request = httpx.Request("POST", "https://api.example.test")
+    request = _fake_request()
 
     class FakeCompletions:
         async def create(self, **kwargs: object) -> object:
             del kwargs
             raise openai.RateLimitError(
                 "rate limited token=abc123 sk-testSECRET123",
-                response=httpx.Response(429, request=request),
+                response=_fake_response(429, request),
                 body=None,
             )
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -74,7 +74,7 @@ def test_release_docs_describe_stable_surface() -> None:
     operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
     changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Version `1.8.2` is the stable production release." in readme
+    assert "Version `1.8.3` is the stable production release." in readme
     assert "librarian admin page-manifest" in operations
     assert "librarian maintainer eval" in operations
     assert "## 1.0.0 - 2026-05-22" in changelog

--- a/uv.lock
+++ b/uv.lock
@@ -1048,7 +1048,7 @@ wheels = [
 
 [[package]]
 name = "nampara-librarian"
-version = "1.8.2"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Security patch cut from current `main`, plus a figure-vision fix.

1.8.2 was tagged at `bb125f0`, *before* the pillow and cryptography security bumps merged, so the shipped 1.8.2 macOS app + Docker image (which pin from `uv.lock`/`constraints.txt`) still bundle the vulnerable versions. 1.8.3 releases from current `main`, which already carries the fixes, so they actually ship in the bundle:

- **pillow 12.2.0 → 12.3.0** — resolves 12 advisories (PYSEC-2026-2253/2254/2255/2256, 3451–3454, 3493–3496) — merged in #56.
- **cryptography 48.0.1 → 50.0.0** — resolves 3 advisories (PYSEC-2026-3552/3553/3554) — merged in #58.

`pip install`/source users on 1.8.2 already resolved the fixed versions via the `&gt;=` ranges; this release matters most for the **pinned macOS app and Docker bundles**.

## Also in this PR

- **Figure-vision fix.** liteparse 2.2.x emits embedded-image placeholders as `[](img_p1_1.png)` at runtime, but Librarian only matched the older `[](image_...)` form, so figure enrichment silently did nothing even with `LIBRARIAN_FIGURE_VISION_ENABLED=true` (two liteparse tests were red on `main`). Enrichment now matches either form.
- **Intel (x86_64) macOS DMG discontinued — Apple Silicon only.** cryptography dropped all Intel macOS wheels at 49.0.0, the same release that fixed the advisories above, so a self-contained *and* patched Intel app can no longer be cross-built from prebuilt wheels (the x86_64 dmg job failed with `ResolutionImpossible`). The x86_64 build is removed from `macapp.yml`/`release.yml`; Intel Mac users install via `pip` or Docker, which stay patched. README + CHANGELOG updated.
- **Test typing hardening.** Route openai's exception test doubles through `Any`-typed helpers so pyright stays stable when CI's latest httpx drifts from openai's vendored `httpx2` stubs.

## Verification

- [x] `ruff check .`, `pyright` — green in CI
- [x] `pytest` (ubuntu `test` + `test-macos`) — green in CI (incl. the liteparse figure-vision tests)
- [x] `python -m build` (1.8.3 wheel + sdist), wheel smoke install, Docker build — green
- [x] Apple Silicon DMG builds, signs, and boots (post-sign smoke test) — green
- [x] `check_changelog_ready.py` for v1.8.3 passes
- [x] `pip-audit` clean on the shipped dependency tree

## Data Safety

- [x] No private documents, transcripts, secrets, provider logs, or sensitive eval outputs added.
- [x] No new fixtures.

## Notes

- After merge, push the `v1.8.3` tag (tag only — **not** via the UI) to build the corrected bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36