### PR TITLE
Harden runtime image: upgrade setuptools, drop pip (vendored msgpack)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,20 @@ COPY src ./src
 # src to build the package, but keeping pip upgrade + the install here (after the
 # dependency files are in place) lets Docker reuse the layer across source-only
 # changes that leave pyproject.toml/constraints.txt untouched.
-RUN python -m pip install --no-cache-dir --upgrade pip \
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools \
     && if [ -f constraints.txt ]; then \
          python -m pip install --no-cache-dir -c constraints.txt ".[all]"; \
        else \
          python -m pip install --no-cache-dir ".[all]"; \
-       fi
+       fi \
+    # Harden the runtime image: it runs `librarian api` and never installs
+    # packages again. Remove pip afterwards so its vendored msgpack copy
+    # (bundled for pip's own HTTP cache, pinned at 1.1.2 —
+    # GHSA-6v7p-g79w-8964) is not shipped in the image; the application's own
+    # msgpack dependency is separately resolved to a fixed version. setuptools
+    # is upgraded in place (>=78.1.1, clearing CVE-2025-47273) rather than
+    # removed, because some dependencies still import pkg_resources at runtime.
+    && python -m pip uninstall -y pip
 
 USER librarian
 VOLUME ["/data"]


### PR DESCRIPTION
## Summary

With the release image-scan gate now scoped to application dependencies (#60), the re-run surfaced **two real HIGH advisories** — both in **packaging tooling shipped in the image**, neither in Librarian's own dependency tree:

| Package | In image | Fixed in | Advisory | Source |
|---------|----------|----------|----------|--------|
| setuptools | 70.3.0 | 78.1.1 | CVE-2025-47273 (PackageIndex path traversal) | base `python:3.12-slim` tooling |
| msgpack | 1.1.2 | 1.2.1 | GHSA-6v7p-g79w-8964 (OOB read on Unpacker reuse) | **pip's vendored copy** (`pip/_vendor`, used by cachecontrol) |

Librarian's *actual* msgpack dependency (via cachecontrol) is already resolved to **1.2.1** in `uv.lock`/`constraints.txt` — the 1.1.2 is only pip's bundled copy.

## Change

In the Dockerfile's install layer:
- Upgrade `pip setuptools` before installing, so **setuptools lands at ≥78.1.1** (currently ~84.x) — clears CVE-2025-47273.
- **Uninstall `pip` after** the app is installed, so its vendored msgpack 1.1.2 isn't shipped — clears GHSA-6v7p-g79w-8964.

The runtime image runs `librarian api` and never installs packages again. Source has **no runtime pip / pkg_resources usage** (grep shows only `"pip install ..."` help strings), so removing pip is safe. `setuptools` is kept (upgraded, not removed) because some dependencies still import `pkg_resources` at runtime.

## Verification

- [x] Confirmed both findings are tooling, not app deps: `constraints.txt` pins `msgpack==1.2.1`; the 1.1.2 is `pip/_vendor/vendor.txt: msgpack==1.1.2`; setuptools is not in the lock.
- [x] Confirmed no runtime pip/pkg_resources use in `src/` (only help strings).
- [x] Validated in a throwaway venv: `pip install --upgrade pip setuptools` → setuptools 84.x; `pip uninstall -y pip` leaves python + setuptools working, pip (and its vendored msgpack) gone.
- Note: the full image can't be built in the sandbox (proxy blocks Debian's apt mirror), so the image build itself is exercised by this PR's Mac App / release CI, not locally. The changed layer only touches pip/PyPI, which is unaffected.

## Follow-up

After merge: re-point the `v1.8.3` tag at the new `main` tip and re-run the release (nothing has been published yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_