### PR TITLE
Docs: correct first-launch Gatekeeper guidance for ad-hoc-signed DMGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,15 @@ All three run the **same engine** and the **same local SQLite library**.
 
 1. Download [**Librarian-AppleSilicon.dmg**](https://github.com/nampara-ai/librarian/releases/latest/download/Librarian-AppleSilicon.dmg)
    (Apple Silicon — M-series). If a direct link doesn't resolve, grab the DMG from the [latest release](https://github.com/nampara-ai/librarian/releases/latest) assets.
-2. Open the DMG and drag **Librarian** to **Applications**. First launch: right-click → **Open** once to clear Gatekeeper.
-3. Drop files anywhere in the window.
+2. Open the DMG and drag **Librarian** to **Applications**.
+3. **First launch — one-time step.** Current builds aren't yet notarized, so macOS will claim
+   *"Librarian" is damaged and can't be opened* — it isn't; that's Gatekeeper reacting to an
+   unnotarized download (the old right-click → Open trick does not clear this one). Run this once
+   in Terminal, then open the app normally:
+   ```bash
+   xattr -cr /Applications/Librarian.app
+   ```
+4. Drop files anywhere in the window.
 
 > **Intel Macs:** the native app is Apple Silicon only — a security-patched
 > self-contained Intel build is no longer possible (a bundled dependency

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -54,10 +54,21 @@ to Applications, double-click, done.
 
 macOS 14 (Sonoma) or newer is required.
 
-**First launch on an unsigned build:** macOS Gatekeeper will warn about an
-unidentified developer. Right-click the app → **Open** → **Open**, or allow it
-under **System Settings → Privacy & Security → Open Anyway**. Notarized
-releases (built with a Developer ID, see below) open without any warning.
+**First launch on an ad-hoc-signed build:** release DMGs built without a
+Developer ID certificate are *ad-hoc* signed. macOS Gatekeeper rejects an
+ad-hoc-signed app that carries the browser's quarantine flag with the message
+*"Librarian" is damaged and can't be opened* — the app is not actually damaged
+(CI boots the exact signed bundle before it ships). Because it reports
+"damaged" rather than "unidentified developer", neither right-click → **Open**
+nor **System Settings → Privacy & Security → Open Anyway** is offered. Clear
+the quarantine flag once, then launch normally:
+
+```bash
+xattr -cr /Applications/Librarian.app
+```
+
+Notarized releases (built with a Developer ID, see below) open without any
+warning and need none of this.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Downloading `Librarian-AppleSilicon.dmg` from the v1.8.3 release and opening it produces:

> *"Librarian" is damaged and can't be opened. You should eject the disk image.*

The app is **not** damaged — CI boots the exact signed bundle before it ships. This is macOS Gatekeeper reacting to a specific combination:

- Release DMGs are **ad-hoc signed** (no Developer ID certificate is configured, so `sign_app.sh` signs with `-`; CI confirms "Sign app (Developer ID)" and "Notarize and staple" are skipped).
- The browser stamps the download with the **quarantine** flag.

Gatekeeper rejects an ad-hoc-signed + quarantined app with the *damaged* message — **not** the "unidentified developer" prompt both READMEs described. Because it reports "damaged", neither right-click → **Open** nor **Privacy & Security → Open Anyway** is offered, so the documented workaround never applied to our builds and users hit a dead end.

## Change

Docs only. Replace the incorrect guidance in `README.md` and `apps/macos/README.md` with the step that actually clears it once:

```bash
xattr -cr /Applications/Librarian.app
```

…plus a plain explanation of why the "damaged" message appears, and a note that notarized (Developer ID) builds need none of this.

## The real fix (not in this PR)

The friction exists because builds aren't notarized. The pipeline already fully supports Developer ID signing + notarization via repository secrets; it needs an Apple Developer Program membership to enable. Until then every user hits this wall — this PR just makes the workaround findable and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_