### PR TITLE
Negotiate LLM request dialect per model (max_completion_tokens, temperature)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- Fix every LLM request failing against current OpenAI models — `Unsupported parameter:
+  'max_tokens'` (GPT-5.x, GPT-6, o-series) and `Unsupported value: 'temperature'` (reasoning
+  models) — which surfaced in the Mac app as "Couldn't process this file" on every chunk. The
+  OpenAI-compatible provider now negotiates the request dialect per model: it starts with the
+  classic `max_tokens`/`temperature` form (still the only form Ollama, LM Studio, DeepSeek and older
+  gateways accept), switches to `max_completion_tokens` and/or drops `temperature` when the server
+  rejects them, and remembers the result so a run of many chunks pays at most one extra round-trip
+  per parameter rather than one per chunk. Applies to every provider preset (Anthropic, OpenAI,
+  DeepSeek, Ollama, LM Studio, Custom), all of which route through this provider.
+
 ## 1.8.3 - 2026-08-23
 
 Dependency security patch plus a figure-vision fix.

--- a/src/librarian/llm/openai_compatible.py
+++ b/src/librarian/llm/openai_compatible.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import os
 import random
+import re
+from dataclasses import dataclass
 from typing import Any, Protocol, cast
 
 from openai import (
@@ -38,6 +40,59 @@ def _content_or_raise(response: ChatCompletion) -> str:
             "increase max_tokens (LIBRARIAN_LLM_MAX_OUTPUT_TOKENS)"
         )
     return choice.message.content or ""
+
+
+@dataclass(slots=True)
+class ModelParamPrefs:
+    """Request-parameter dialect learned from the server, per model.
+
+    Newer OpenAI models reject ``max_tokens`` and require
+    ``max_completion_tokens``; reasoning models (o-series, GPT-5+) additionally
+    reject any non-default ``temperature``. Other OpenAI-compatible servers
+    (Ollama, LM Studio, DeepSeek, older gateways) accept only the classic
+    parameters. Rather than hardcode either dialect, start with the classic
+    form and adapt when a 400 names the offending parameter, remembering the
+    result per model so a run of many chunks pays at most one extra round-trip
+    per parameter instead of one per chunk.
+    """
+
+    use_max_completion_tokens: bool = False
+    omit_temperature: bool = False
+
+
+_UNSUPPORTED_HINT = re.compile(r"unsupported|not supported|does not support", re.I)
+_MAX_TOKENS_HINT = re.compile(r"max_completion_tokens|max_tokens", re.I)
+_TEMPERATURE_HINT = re.compile(r"\btemperature\b", re.I)
+
+
+def unsupported_parameter(exc: Exception) -> str | None:
+    """Return ``"max_tokens"`` or ``"temperature"`` when a 400 rejects that parameter.
+
+    Prefers the structured ``param`` field the OpenAI API sets; falls back to
+    the error message for compatible servers that omit it, but only when the
+    message actually says the parameter is unsupported, so an unrelated 400
+    that merely mentions the word is never mistaken for a dialect mismatch.
+    """
+    if not isinstance(exc, APIStatusError) or int(exc.status_code) != 400:
+        return None
+    param = getattr(exc, "param", None)
+    if param == "max_tokens":
+        return "max_tokens"
+    if param == "temperature":
+        return "temperature"
+    if param is not None:
+        return None
+    body = getattr(exc, "body", None)
+    message = str(exc)
+    if isinstance(body, dict):
+        message = f"{message} {body.get('message', '')}"
+    if not _UNSUPPORTED_HINT.search(message):
+        return None
+    if _MAX_TOKENS_HINT.search(message):
+        return "max_tokens"
+    if _TEMPERATURE_HINT.search(message):
+        return "temperature"
+    return None
 
 
 class LLMUsageMetrics(Protocol):
@@ -86,6 +141,8 @@ class OpenAICompatibleProvider:
         self._metrics = metrics
         self._prompt_cost_per_1k_tokens_usd = prompt_cost_per_1k_tokens_usd
         self._completion_cost_per_1k_tokens_usd = completion_cost_per_1k_tokens_usd
+        # Parameter dialect learned per model (see ModelParamPrefs).
+        self._param_prefs: dict[str, ModelParamPrefs] = {}
 
     async def complete(
         self,
@@ -144,6 +201,24 @@ class OpenAICompatibleProvider:
         self._record_usage(response, model=model)
         return _content_or_raise(response)
 
+    def _request_kwargs(
+        self,
+        *,
+        prefs: ModelParamPrefs,
+        messages: list[Any],
+        model: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"model": model, "messages": cast("Any", messages)}
+        if prefs.use_max_completion_tokens:
+            kwargs["max_completion_tokens"] = max_tokens
+        else:
+            kwargs["max_tokens"] = max_tokens
+        if not prefs.omit_temperature:
+            kwargs["temperature"] = temperature
+        return kwargs
+
     async def _chat_with_retries(
         self,
         *,
@@ -152,25 +227,48 @@ class OpenAICompatibleProvider:
         max_tokens: int,
         temperature: float,
     ) -> ChatCompletion:
-        last_error: Exception | None = None
-        for attempt in range(self._max_retries + 1):
+        prefs = self._param_prefs.setdefault(model, ModelParamPrefs())
+        # One adaptation per parameter at most; a dialect mismatch is resolved
+        # by resending immediately (no backoff, no transient-retry budget
+        # consumed). Anything the server still rejects afterwards is a genuine
+        # request error and surfaces as such.
+        max_adaptations = 2
+        adaptations = 0
+        attempt = 0
+        while True:
+            kwargs = self._request_kwargs(
+                prefs=prefs,
+                messages=messages,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
             try:
-                return await self._client.chat.completions.create(
-                    model=model,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    messages=cast("Any", messages),
+                # Kwargs are assembled dynamically (dialect varies per model),
+                # which defeats the SDK's typed overloads; the API contract
+                # is still a ChatCompletion.
+                return cast(
+                    "ChatCompletion",
+                    await self._client.chat.completions.create(**kwargs),
                 )
             except Exception as exc:  # noqa: BLE001 - provider errors feed retry policy
+                rejected = unsupported_parameter(exc)
+                if adaptations < max_adaptations:
+                    if rejected == "max_tokens" and not prefs.use_max_completion_tokens:
+                        prefs.use_max_completion_tokens = True
+                        adaptations += 1
+                        continue
+                    if rejected == "temperature" and not prefs.omit_temperature:
+                        prefs.omit_temperature = True
+                        adaptations += 1
+                        continue
                 if not is_retriable_openai_error(exc):
                     raise RuntimeError(
                         f"LLM provider request failed: {sanitize_error_message(exc)}"
                     ) from None
-                last_error = exc
                 if attempt >= self._max_retries:
                     raise RuntimeError(
-                        "LLM provider request failed after retries: "
-                        f"{sanitize_error_message(exc)}"
+                        f"LLM provider request failed after retries: {sanitize_error_message(exc)}"
                     ) from None
                 delay = min(
                     self._retry_base_delay_seconds * (2**attempt),
@@ -178,13 +276,7 @@ class OpenAICompatibleProvider:
                 )
                 jitter = random.uniform(0, delay * 0.1)  # noqa: S311
                 await asyncio.sleep(delay + jitter)
-
-        if last_error is not None:
-            raise RuntimeError(
-                "LLM provider request failed after retries: "
-                f"{sanitize_error_message(last_error)}"
-            ) from None
-        raise RuntimeError("LLM completion failed without an exception")
+                attempt += 1
 
     def _record_usage(self, response: ChatCompletion, *, model: str) -> None:
         if self._metrics is None or response.usage is None:

--- a/tests/test_openai_compatible.py
+++ b/tests/test_openai_compatible.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any, cast
 
 import httpx
@@ -6,7 +7,11 @@ import pytest
 
 from librarian.config import Settings
 from librarian.llm import build_provider
-from librarian.llm.openai_compatible import OpenAICompatibleProvider, is_retriable_openai_error
+from librarian.llm.openai_compatible import (
+    OpenAICompatibleProvider,
+    is_retriable_openai_error,
+    unsupported_parameter,
+)
 from librarian.observability import MetricsRecorder
 
 
@@ -321,3 +326,261 @@ async def test_build_provider_rejects_oversized_prompts_before_provider_call() -
 
 async def _no_sleep(_: float) -> None:
     return None
+
+
+# --- request-dialect negotiation ---------------------------------------------
+#
+# Newer OpenAI models reject `max_tokens` (requiring `max_completion_tokens`)
+# and reasoning models reject any non-default `temperature`; other
+# OpenAI-compatible servers accept only the classic form. The provider must
+# adapt on a 400 that names the parameter and remember the answer per model.
+
+_MAX_TOKENS_MSG = (
+    "Unsupported parameter: 'max_tokens' is not supported with this model. "
+    "Use 'max_completion_tokens' instead."
+)
+_TEMPERATURE_MSG = (
+    "Unsupported value: 'temperature' does not support 0 with this model. "
+    "Only the default (1) value is supported."
+)
+
+
+def _bad_request(*, param: str | None, code: str, message: str) -> Any:
+    body = {"message": message, "type": "invalid_request_error", "param": param, "code": code}
+    return openai.BadRequestError(message, response=_fake_response(400, _fake_request()), body=body)
+
+
+def _install_scripted_client(
+    monkeypatch: pytest.MonkeyPatch,
+    script: Callable[[dict[str, Any]], None],
+) -> list[dict[str, Any]]:
+    """Fake AsyncOpenAI whose create() records its kwargs, then runs `script`.
+
+    `script(kwargs)` raises to fail that call or returns to succeed. The
+    returned list holds every kwargs dict sent, so tests can assert exactly
+    which parameters went over the wire on each attempt.
+    """
+    sent: list[dict[str, Any]] = []
+
+    class FakeChoice:
+        class Message:
+            content = "ok"
+
+        message = Message()
+
+    class FakeCompletion:
+        choices = [FakeChoice()]
+        usage = None
+
+    class FakeCompletions:
+        async def create(self, **kwargs: Any) -> Any:
+            sent.append(dict(kwargs))
+            script(kwargs)
+            return FakeCompletion()
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeClient:
+        chat = FakeChat()
+
+    def fake_async_openai(**kwargs: object) -> FakeClient:
+        del kwargs
+        return FakeClient()
+
+    monkeypatch.setenv("LIBRARIAN_TEST_API_KEY", "test")
+    monkeypatch.setattr("librarian.llm.openai_compatible.AsyncOpenAI", fake_async_openai)
+    monkeypatch.setattr("librarian.llm.openai_compatible.asyncio.sleep", _no_sleep)
+    return sent
+
+
+def _scripted_provider() -> OpenAICompatibleProvider:
+    return OpenAICompatibleProvider(
+        api_key_env="LIBRARIAN_TEST_API_KEY",
+        base_url=None,
+        timeout_seconds=1,
+        max_concurrency=1,
+        max_retries=0,
+    )
+
+
+async def _complete(provider: OpenAICompatibleProvider, model: str) -> str:
+    return await provider.complete(
+        system_prompt="system",
+        user_prompt="user",
+        model=model,
+        max_tokens=8,
+        temperature=0,
+    )
+
+
+def test_unsupported_parameter_classification() -> None:
+    # The structured `param` field the OpenAI API sets is authoritative.
+    assert (
+        unsupported_parameter(
+            _bad_request(param="max_tokens", code="unsupported_parameter", message=_MAX_TOKENS_MSG)
+        )
+        == "max_tokens"
+    )
+    assert (
+        unsupported_parameter(
+            _bad_request(param="temperature", code="unsupported_value", message=_TEMPERATURE_MSG)
+        )
+        == "temperature"
+    )
+    # Compatible servers that omit `param` are classified from the message...
+    assert (
+        unsupported_parameter(_bad_request(param=None, code="invalid", message=_MAX_TOKENS_MSG))
+        == "max_tokens"
+    )
+    assert (
+        unsupported_parameter(_bad_request(param=None, code="invalid", message=_TEMPERATURE_MSG))
+        == "temperature"
+    )
+    # ...but only when it actually says the parameter is unsupported: a 400
+    # that merely mentions max_tokens (a range error) must not trigger a
+    # dialect switch.
+    assert (
+        unsupported_parameter(
+            _bad_request(param=None, code="invalid", message="max_tokens must be at least 1")
+        )
+        is None
+    )
+    # A 400 naming an unrelated parameter is a genuine request error.
+    assert (
+        unsupported_parameter(
+            _bad_request(
+                param="model", code="model_not_found", message="The model `nope` does not exist"
+            )
+        )
+        is None
+    )
+    # Non-400 failures are never dialect mismatches.
+    assert (
+        unsupported_parameter(
+            openai.RateLimitError(
+                "rate limited", response=_fake_response(429, _fake_request()), body=None
+            )
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_adapts_max_tokens_to_max_completion_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def script(kwargs: dict[str, Any]) -> None:
+        if "max_tokens" in kwargs:
+            raise _bad_request(
+                param="max_tokens", code="unsupported_parameter", message=_MAX_TOKENS_MSG
+            )
+
+    sent = _install_scripted_client(monkeypatch, script)
+    provider = _scripted_provider()
+
+    assert await _complete(provider, "gpt-5") == "ok"
+
+    # First send used the classic parameter; the immediate resend switched.
+    assert "max_tokens" in sent[0] and "max_completion_tokens" not in sent[0]
+    assert sent[1]["max_completion_tokens"] == 8 and "max_tokens" not in sent[1]
+    assert len(sent) == 2
+
+    # The dialect is remembered: the next call goes straight to the accepted form.
+    assert await _complete(provider, "gpt-5") == "ok"
+    assert len(sent) == 3
+    assert sent[2]["max_completion_tokens"] == 8 and "max_tokens" not in sent[2]
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_omits_temperature_when_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def script(kwargs: dict[str, Any]) -> None:
+        if "temperature" in kwargs:
+            raise _bad_request(
+                param="temperature", code="unsupported_value", message=_TEMPERATURE_MSG
+            )
+
+    sent = _install_scripted_client(monkeypatch, script)
+    provider = _scripted_provider()
+
+    assert await _complete(provider, "o4-mini") == "ok"
+    assert "temperature" in sent[0]
+    assert "temperature" not in sent[1]
+    assert len(sent) == 2
+
+    assert await _complete(provider, "o4-mini") == "ok"
+    assert len(sent) == 3 and "temperature" not in sent[2]
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_adapts_both_params_for_reasoning_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A reasoning model rejects max_tokens first and, once that is fixed,
+    # temperature — the provider converges in two adaptations, no backoff.
+    def script(kwargs: dict[str, Any]) -> None:
+        if "max_tokens" in kwargs:
+            raise _bad_request(
+                param="max_tokens", code="unsupported_parameter", message=_MAX_TOKENS_MSG
+            )
+        if "temperature" in kwargs:
+            raise _bad_request(
+                param="temperature", code="unsupported_value", message=_TEMPERATURE_MSG
+            )
+
+    sent = _install_scripted_client(monkeypatch, script)
+    provider = _scripted_provider()
+
+    assert await _complete(provider, "gpt-5") == "ok"
+    assert len(sent) == 3
+    final = sent[2]
+    assert final["max_completion_tokens"] == 8
+    assert "max_tokens" not in final and "temperature" not in final
+
+    # Both learned: a follow-up is a single, correctly-shaped request.
+    assert await _complete(provider, "gpt-5") == "ok"
+    assert len(sent) == 4
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_does_not_adapt_unrelated_bad_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def script(kwargs: dict[str, Any]) -> None:
+        del kwargs
+        raise _bad_request(
+            param="model", code="model_not_found", message="The model `nope` does not exist"
+        )
+
+    sent = _install_scripted_client(monkeypatch, script)
+    provider = _scripted_provider()
+
+    with pytest.raises(RuntimeError, match="LLM provider request failed"):
+        await _complete(provider, "nope")
+    # No adaptation loop for a genuine request error: it fails fast on the
+    # first attempt exactly like any other non-retriable 400.
+    assert len(sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_param_adaptation_is_per_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def script(kwargs: dict[str, Any]) -> None:
+        if kwargs["model"] == "gpt-5" and "max_tokens" in kwargs:
+            raise _bad_request(
+                param="max_tokens", code="unsupported_parameter", message=_MAX_TOKENS_MSG
+            )
+
+    sent = _install_scripted_client(monkeypatch, script)
+    provider = _scripted_provider()
+
+    await _complete(provider, "gpt-5")
+    # gpt-5 learned the new dialect; an older model on the same provider must
+    # still receive the classic parameter it expects.
+    await _complete(provider, "gpt-4.1-mini")
+    last = sent[-1]
+    assert last["model"] == "gpt-4.1-mini"
+    assert "max_tokens" in last and "max_completion_tokens" not in last


### PR DESCRIPTION
## Summary

**Every LLM request was failing against current OpenAI models**, surfacing in the Mac app as *"Couldn't process this file"* on every chunk:

```
LLM provider request failed: Error code: 400 - {'error': {'message': "Unsupported parameter:
'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", ...
'param': 'max_tokens', 'code': 'unsupported_parameter'}}
```

Root cause: `OpenAICompatibleProvider._chat_with_retries` always sent `max_tokens` and `temperature=0`. GPT-5.x / GPT-6 / o-series **reject `max_tokens`** (requiring `max_completion_tokens`), and reasoning models **reject any non-default `temperature`** (`Unsupported value: 'temperature' does not support 0`). A 400 is non-retriable, so each chunk failed instantly.

**Every provider preset is affected** — Anthropic (via its OpenAI-compatible endpoint), OpenAI, DeepSeek, Ollama, LM Studio, Custom — because they all route through this single provider.

## Why not just switch to the new parameter names

This is an *OpenAI-compatible* provider talking to unknown servers. Ollama, LM Studio, DeepSeek and older gateways accept **only** the classic `max_tokens`/`temperature`. Hardcoding either dialect breaks half the presets.

## Change

**Per-model dialect negotiation.** Send the classic form first; when a 400 names the offending parameter, immediately resend with the corrected form and **remember it per model**:

- `param == "max_tokens"` → switch to `max_completion_tokens`
- `param == "temperature"` → omit `temperature`

Detection prefers the API's structured `param` field, with a message-based fallback for compatible servers that omit it — gated so it only fires when the message actually says the parameter is *unsupported* (a range error like "max_tokens must be at least 1" must not trigger a switch).

Properties:
- **Bounded**: at most one switch per parameter; no loops.
- **Cheap**: adaptation is an immediate resend — no backoff, consumes no transient-retry budget. A run of 58 chunks pays at most 1–2 extra round-trips total, not per chunk.
- **Safe**: an unrelated 400 (unknown model, bad key) still fails fast exactly as before.
- `describe_image` (figure vision) inherits the fix via the shared path.

## Verification

- [x] `ruff check` + `ruff format --check` clean
- [x] `pyright` — 0 errors
- [x] `pytest tests/test_openai_compatible.py` — **13 passed** (7 existing + 6 new)
- [x] Full suite: 591 passed; the only 6 failures are the known sandbox-only tessdata-download `403`s in the liteparse tests (proxy-blocked here, green in CI), unrelated to this diff

New tests cover: each adaptation individually, both combined (reasoning-model sequence), that the dialect is remembered, that it is per-model, that unrelated 400s are not adapted, and the classifier's structured / fallback / negative cases.

## Data Safety

- [x] No private documents, secrets, or provider logs added.
- [x] No new fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36

---
_Generated by [Claude Code](https://claude.ai/code/session_013FBed2M9J4AfhQuh6oBM36)_